### PR TITLE
feat: display login page at root

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,8 +4,12 @@ import { LoginComponent } from './auth/login.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 
 const routes: Routes = [
-  { path: '', redirectTo: 'login', pathMatch: 'full' },
+  // Show the login component when the root path is visited
+  { path: '', component: LoginComponent, pathMatch: 'full' },
+
+  // Alias to access the login using '/login'
   { path: 'login', component: LoginComponent },
+
   { path: 'dashboard', component: DashboardComponent }
 ];
 


### PR DESCRIPTION
## Summary
- show the login component when visiting `/`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684affcf7340832d88812657c9d5ad51