### PR TITLE
Improve login form

### DIFF
--- a/src/app/auth/login.component.css
+++ b/src/app/auth/login.component.css
@@ -1,13 +1,23 @@
 .login-container {
-  max-width: 300px;
-  margin: 100px auto;
+  max-width: 320px;
+  margin: 80px auto;
   padding: 20px;
   border: 1px solid #ccc;
   border-radius: 4px;
+  background-color: white;
+  color: black;
 }
-.login-container div {
-  margin-bottom: 10px;
+
+.login-container .form-group {
+  margin-bottom: 15px;
 }
+
+.login-container input {
+  width: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
 .error {
   color: red;
 }

--- a/src/app/auth/login.component.html
+++ b/src/app/auth/login.component.html
@@ -1,15 +1,15 @@
 <div class="login-container">
-  <h2>Login</h2>
+  <h2>Iniciar Sesión</h2>
   <form (ngSubmit)="login()" #loginForm="ngForm">
-    <div>
-      <label>Username</label>
-      <input name="username" [(ngModel)]="username" required />
+    <div class="form-group">
+      <label for="email">Correo electrónico</label>
+      <input id="email" type="email" name="email" [(ngModel)]="email" required />
     </div>
-    <div>
-      <label>Password</label>
-      <input type="password" name="password" [(ngModel)]="password" required />
+    <div class="form-group">
+      <label for="password">Contraseña</label>
+      <input id="password" type="password" name="password" [(ngModel)]="password" required />
     </div>
-    <button type="submit">Login</button>
+    <button type="submit">Iniciar sesión</button>
     <div class="error" *ngIf="error">{{error}}</div>
   </form>
 </div>

--- a/src/app/auth/login.component.ts
+++ b/src/app/auth/login.component.ts
@@ -8,7 +8,7 @@ import { HttpClient } from '@angular/common/http';
   styleUrls: ['./login.component.css']
 })
 export class LoginComponent {
-  username = '';
+  email = '';
   password = '';
   error = '';
 
@@ -17,7 +17,7 @@ export class LoginComponent {
   login() {
     this.error = '';
     this.http.post<any>('http://localhost:3000/auth/login', {
-      username: this.username,
+      email: this.email,
       password: this.password
     }).subscribe({
       next: (res) => {


### PR DESCRIPTION
## Summary
- implement a login form styled with inputs for email and password

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b00d802fc832da1b1ab3b3078d75e