### PR TITLE
Fix login route redirection

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,13 +4,17 @@ import { LoginComponent } from './auth/login.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 
 const routes: Routes = [
-  // Show the login component when the root path is visited
-  { path: '', component: LoginComponent, pathMatch: 'full' },
-
-  // Alias to access the login using '/login'
+  // Route to access the login directly
   { path: 'login', component: LoginComponent },
 
-  { path: 'dashboard', component: DashboardComponent }
+  // Route to the dashboard after successful login
+  { path: 'dashboard', component: DashboardComponent },
+
+  // Redirect the root path to the login page
+  { path: '', redirectTo: 'login', pathMatch: 'full' },
+
+  // Redirect any unknown route to the login page
+  { path: '**', redirectTo: 'login' }
 ];
 
 @NgModule({


### PR DESCRIPTION
## Summary
- adjust Angular routes so root and unknown routes redirect to `/login`

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b04cb8378832d9b1c76b8b1fd9edf