### PR TITLE
Add login form validation

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -49,3 +49,9 @@
   margin-top: 0.5rem;
   width: 100%;
 }
+
+.error {
+  color: #ff6b6b;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,16 +1,38 @@
 <div class="login-container">
   <h1>Iniciar sesión</h1>
-  <form>
+  <form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
     <div class="form-group">
       <label for="username">Correo electrónico</label>
-      <input id="username" name="username" type="email" placeholder="tucorreo@ejemplo.com" />
+      <input
+        id="username"
+        name="username"
+        type="email"
+        formControlName="username"
+        placeholder="tucorreo@ejemplo.com"
+      />
+      <div class="error" *ngIf="loginForm.get('username')?.touched && loginForm.get('username')?.hasError('required')">
+        El correo es requerido
+      </div>
+      <div class="error" *ngIf="loginForm.get('username')?.touched && loginForm.get('username')?.hasError('email')">
+        Ingresa un correo válido
+      </div>
     </div>
     <div class="form-group">
       <label for="password">Contraseña</label>
-      <input id="password" name="password" type="password" placeholder="Ingresa tu contraseña" />
+      <input
+        id="password"
+        name="password"
+        type="password"
+        formControlName="password"
+        placeholder="Ingresa tu contraseña"
+      />
+      <div class="error" *ngIf="loginForm.get('password')?.touched && loginForm.get('password')?.hasError('required')">
+        La contraseña es requerida
+      </div>
     </div>
     <div class="form-actions">
       <button type="submit">Continuar</button>
     </div>
   </form>
+  <div class="error" *ngIf="error">{{ error }}</div>
 </div>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,9 +1,11 @@
 import { TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(() => TestBed.configureTestingModule({
-    declarations: [AppComponent]
+    declarations: [AppComponent],
+    imports: [ReactiveFormsModule]
   }));
 
   it('should create the app', () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 
 @Component({
   selector: 'app-root',
@@ -7,4 +8,28 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'app-test';
+  loginForm: FormGroup;
+  error = '';
+
+  constructor(private fb: FormBuilder) {
+    this.loginForm = this.fb.group({
+      username: ['', [Validators.required, Validators.email]],
+      password: ['', Validators.required]
+    });
+  }
+
+  onSubmit(): void {
+    this.error = '';
+    if (this.loginForm.invalid) {
+      this.loginForm.markAllAsTouched();
+      return;
+    }
+
+    const { username, password } = this.loginForm.value;
+    if (username === 'admin@example.com' && password === 'admin') {
+      alert('Inicio de sesión exitoso');
+    } else {
+      this.error = 'Los datos son incorrectos';
+    }
+  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,11 +1,12 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { ReactiveFormsModule } from '@angular/forms';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [BrowserModule, AppRoutingModule],
+  imports: [BrowserModule, AppRoutingModule, ReactiveFormsModule],
   providers: [],
   bootstrap: [AppComponent]
 })


### PR DESCRIPTION
## Summary
- add `ReactiveFormsModule` to the app module
- implement reactive form and credential checks in `AppComponent`
- show validation errors in the template and style them
- fix unit tests to include `ReactiveFormsModule`

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b0c3ea380832d86a9844cb9d5d4ec