### PR TITLE
Add dashboard with sidebar

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<div class="login-container">
+<div class="login-container" *ngIf="!isLoggedIn">
   <h1>Iniciar sesión</h1>
   <form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
     <div class="form-group">
@@ -36,3 +36,5 @@
   </form>
   <div class="error" *ngIf="error">{{ error }}</div>
 </div>
+
+<app-dashboard *ngIf="isLoggedIn" [user]="user"></app-dashboard>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,8 @@ export class AppComponent {
   title = 'app-test';
   loginForm: FormGroup;
   error = '';
+  isLoggedIn = false;
+  user: { name: string; company: string } | null = null;
 
   constructor(private fb: FormBuilder) {
     this.loginForm = this.fb.group({
@@ -27,7 +29,8 @@ export class AppComponent {
 
     const { username, password } = this.loginForm.value;
     if (username === 'admin@example.com' && password === 'admin') {
-      alert('Inicio de sesión exitoso');
+      this.isLoggedIn = true;
+      this.user = { name: 'Admin', company: 'Empresa Ejemplo' };
     } else {
       this.error = 'Los datos son incorrectos';
     }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,9 +3,10 @@ import { BrowserModule } from '@angular/platform-browser';
 import { ReactiveFormsModule } from '@angular/forms';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { DashboardComponent } from './dashboard/dashboard.component';
 
 @NgModule({
-  declarations: [AppComponent],
+  declarations: [AppComponent, DashboardComponent],
   imports: [BrowserModule, AppRoutingModule, ReactiveFormsModule],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -1,0 +1,64 @@
+.dashboard {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  background: #444654;
+  color: #fff;
+  padding: 0.5rem 1rem;
+}
+
+.hamburger {
+  font-size: 1.5rem;
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  margin-right: 1rem;
+}
+
+.body {
+  flex: 1;
+  display: flex;
+}
+
+.sidemenu {
+  width: 200px;
+  background: #343541;
+  color: #fff;
+  transition: transform 0.3s ease;
+  transform: translateX(-100%);
+}
+
+.sidemenu.open {
+  transform: translateX(0);
+}
+
+.sidemenu ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.menu-item {
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+}
+
+.submenu {
+  display: none;
+  padding-left: 1rem;
+}
+
+.submenu.open {
+  display: block;
+}
+
+.content {
+  flex: 1;
+  padding: 1rem;
+}

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,0 +1,31 @@
+<div class="dashboard">
+  <header class="topbar">
+    <button class="hamburger" (click)="toggleMenu()">&#9776;</button>
+    <div class="userinfo" *ngIf="user">
+      {{ user.name }} - {{ user.company }}
+    </div>
+  </header>
+  <div class="body">
+    <nav class="sidemenu" [class.open]="menuOpen">
+      <ul>
+        <li>
+          <div class="menu-item" (click)="toggleSubmenu('m1')">Menú 1</div>
+          <ul class="submenu" [class.open]="submenus['m1']">
+            <li>Submenú 1-1</li>
+            <li>Submenú 1-2</li>
+          </ul>
+        </li>
+        <li>
+          <div class="menu-item" (click)="toggleSubmenu('m2')">Menú 2</div>
+          <ul class="submenu" [class.open]="submenus['m2']">
+            <li>Submenú 2-1</li>
+            <li>Submenú 2-2</li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
+    <main class="content">
+      <h2>Bienvenido al dashboard</h2>
+    </main>
+  </div>
+</div>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,0 +1,20 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.css']
+})
+export class DashboardComponent {
+  @Input() user: { name: string; company: string } | null = null;
+  menuOpen = false;
+  submenus: Record<string, boolean> = {};
+
+  toggleMenu(): void {
+    this.menuOpen = !this.menuOpen;
+  }
+
+  toggleSubmenu(key: string): void {
+    this.submenus[key] = !this.submenus[key];
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple DashboardComponent with collapsible sidebar
- show dashboard after successful login
- display logged user name and company in the dashboard header

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0d4cce84832da8593f76bc4ca142