### PR TITLE
Add third-level submenu

### DIFF
--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -89,6 +89,19 @@
   display: block;
 }
 
+.subsubmenu {
+  display: none;
+  background: #3c3d46;
+}
+
+.subsubmenu li {
+  padding: 0.5rem 2.5rem;
+}
+
+.subsubmenu.open {
+  display: block;
+}
+
 .content {
   flex: 1;
   padding: 1rem;

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -14,7 +14,16 @@
             <span class="arrow" [class.open]="submenus['m1']">&#9654;</span>
           </div>
           <ul class="submenu" [class.open]="submenus['m1']">
-            <li>Submenú 1-1</li>
+            <li>
+              <div class="menu-item" (click)="toggleSubsubmenu('m1-1')">
+                <span>Submenú 1-1</span>
+                <span class="arrow" [class.open]="subsubmenus['m1-1']">&#9654;</span>
+              </div>
+              <ul class="subsubmenu" [class.open]="subsubmenus['m1-1']">
+                <li>Opción 1-1-1</li>
+                <li>Opción 1-1-2</li>
+              </ul>
+            </li>
             <li>Submenú 1-2</li>
           </ul>
         </li>
@@ -24,7 +33,16 @@
             <span class="arrow" [class.open]="submenus['m2']">&#9654;</span>
           </div>
           <ul class="submenu" [class.open]="submenus['m2']">
-            <li>Submenú 2-1</li>
+            <li>
+              <div class="menu-item" (click)="toggleSubsubmenu('m2-1')">
+                <span>Submenú 2-1</span>
+                <span class="arrow" [class.open]="subsubmenus['m2-1']">&#9654;</span>
+              </div>
+              <ul class="subsubmenu" [class.open]="subsubmenus['m2-1']">
+                <li>Opción 2-1-1</li>
+                <li>Opción 2-1-2</li>
+              </ul>
+            </li>
             <li>Submenú 2-2</li>
           </ul>
         </li>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -9,6 +9,7 @@ export class DashboardComponent {
   @Input() user: { name: string; company: string } | null = null;
   menuOpen = false;
   submenus: Record<string, boolean> = {};
+  subsubmenus: Record<string, boolean> = {};
 
   toggleMenu(): void {
     this.menuOpen = !this.menuOpen;
@@ -16,5 +17,9 @@ export class DashboardComponent {
 
   toggleSubmenu(key: string): void {
     this.submenus[key] = !this.submenus[key];
+  }
+
+  toggleSubsubmenu(key: string): void {
+    this.subsubmenus[key] = !this.subsubmenus[key];
   }
 }


### PR DESCRIPTION
## Summary
- expand menu to support a third level
- style new subsubmenu elements

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b1652aa80832dab8424077ed27c9b