### PR TITLE
Show owner company on dashboard

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,13 @@ import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 
+interface LoginResponse {
+  message: string;
+  token: string;
+  user: { id: number; username: string };
+  ownerCompany: { id: number; name: string };
+}
+
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -30,15 +37,16 @@ export class AppComponent {
 
     const { username, password } = this.loginForm.value;
     this.http
-      .post<{ message: string; token: string }>(
+      .post<LoginResponse>(
         'http://localhost:3000/auth/login',
         { username, password }
       )
       .subscribe({
         next: (res) => {
           document.cookie = `token=${res.token}; path=/`;
+          document.cookie = `loginData=${encodeURIComponent(JSON.stringify(res))}; path=/`;
           this.isLoggedIn = true;
-          this.user = { name: username, company: '' };
+          this.user = { name: res.user.username, company: res.ownerCompany.name };
         },
         error: () => {
           this.error = 'Los datos son incorrectos';


### PR DESCRIPTION
## Summary
- update login request to match new response
- store full login response in a `loginData` cookie
- display the company name returned from the API in the dashboard header

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b18bc502c832d85edab4aae5c5de6