### PR TITLE
Add session persistence and logout

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -37,4 +37,4 @@
   <div class="error" *ngIf="error">{{ error }}</div>
 </div>
 
-<app-dashboard *ngIf="isLoggedIn" [user]="user"></app-dashboard>
+<app-dashboard *ngIf="isLoggedIn" [user]="user" (logout)="logout()"></app-dashboard>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 interface LoginResponse {
   message: string;
@@ -14,18 +14,76 @@ interface LoginResponse {
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'app-test';
   loginForm: FormGroup;
   error = '';
   isLoggedIn = false;
   user: { name: string; company: string } | null = null;
+  private inactivityTimeout: any;
+
+  ngOnInit(): void {
+    const loginData = this.getCookie('loginData');
+    if (loginData) {
+      try {
+        const res: LoginResponse = JSON.parse(decodeURIComponent(loginData));
+        this.isLoggedIn = true;
+        this.user = { name: res.user.username, company: res.ownerCompany.name };
+        this.resetInactivityTimer();
+      } catch (_) {
+        // ignore parse errors
+      }
+    }
+  }
+
+  @HostListener('document:mousemove')
+  @HostListener('document:keydown')
+  @HostListener('document:click')
+  handleActivity(): void {
+    this.resetInactivityTimer();
+  }
 
   constructor(private fb: FormBuilder, private http: HttpClient) {
     this.loginForm = this.fb.group({
       username: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required]
     });
+  }
+
+  private getCookie(name: string): string | null {
+    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+    return match ? decodeURIComponent(match[2]) : null;
+  }
+
+  private resetInactivityTimer(): void {
+    if (!this.isLoggedIn) {
+      return;
+    }
+    clearTimeout(this.inactivityTimeout);
+    this.inactivityTimeout = setTimeout(() => this.performLogout(), 10 * 60 * 1000);
+  }
+
+  logout(): void {
+    this.performLogout();
+  }
+
+  private performLogout(): void {
+    const token = this.getCookie('token');
+    const options = token ? { headers: new HttpHeaders({ token }) } : {};
+    this.http
+      .post('http://localhost:3000/auth/logout', {}, options)
+      .subscribe({
+        complete: () => this.clearSession(),
+        error: () => this.clearSession()
+      });
+  }
+
+  private clearSession(): void {
+    this.isLoggedIn = false;
+    this.user = null;
+    document.cookie = 'token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    document.cookie = 'loginData=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+    clearTimeout(this.inactivityTimeout);
   }
 
   onSubmit(): void {
@@ -47,6 +105,7 @@ export class AppComponent {
           document.cookie = `loginData=${encodeURIComponent(JSON.stringify(res))}; path=/`;
           this.isLoggedIn = true;
           this.user = { name: res.user.username, company: res.ownerCompany.name };
+          this.resetInactivityTimer();
         },
         error: () => {
           this.error = 'Los datos son incorrectos';

--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -21,6 +21,16 @@
   margin-right: 1rem;
 }
 
+.logout {
+  margin-left: auto;
+  background: #ff6b6b;
+  border: none;
+  color: #fff;
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
 .body {
   flex: 1;
   display: flex;

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -4,6 +4,7 @@
     <div class="userinfo" *ngIf="user">
       {{ user.name }} - {{ user.company }}
     </div>
+    <button class="logout" (click)="onLogout()">Cerrar sesión</button>
   </header>
   <div class="body">
     <nav class="sidemenu" [class.open]="menuOpen">

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'app-dashboard',
@@ -7,6 +7,7 @@ import { Component, Input } from '@angular/core';
 })
 export class DashboardComponent {
   @Input() user: { name: string; company: string } | null = null;
+  @Output() logout = new EventEmitter<void>();
   menuOpen = false;
   submenus: Record<string, boolean> = {};
   subsubmenus: Record<string, boolean> = {};
@@ -21,5 +22,9 @@ export class DashboardComponent {
 
   toggleSubsubmenu(key: string): void {
     this.subsubmenus[key] = !this.subsubmenus[key];
+  }
+
+  onLogout(): void {
+    this.logout.emit();
   }
 }


### PR DESCRIPTION
## Summary
- keep login info in cookie and restore on page load
- add inactivity logout after 10 minutes
- provide logout button in dashboard

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1b838328832dbec00c3f944bf496