### PR TITLE
Add settings view and dynamic dashboard content

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,9 +5,10 @@ import { HttpClientModule } from '@angular/common/http';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
+import { SettingsComponent } from './settings/settings.component';
 
 @NgModule({
-  declarations: [AppComponent, DashboardComponent],
+  declarations: [AppComponent, DashboardComponent, SettingsComponent],
   imports: [BrowserModule, AppRoutingModule, ReactiveFormsModule, HttpClientModule],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -44,6 +44,8 @@
   transition: transform 0.3s ease;
   transform: translateX(-100%);
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidemenu.open {
@@ -54,6 +56,9 @@
   list-style: none;
   padding: 0;
   margin: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .sidemenu li {
@@ -115,4 +120,8 @@
 .content {
   flex: 1;
   padding: 1rem;
+}
+
+.bottom-item {
+  margin-top: auto;
 }

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -47,10 +47,17 @@
             <li>Submenú 2-2</li>
           </ul>
         </li>
+        <li class="bottom-item" (click)="selectView('settings')">
+          <div class="menu-item">
+            <span class="icon">&#9881;</span>
+            <span>Configuración</span>
+          </div>
+        </li>
       </ul>
     </nav>
     <main class="content">
-      <h2>Bienvenido al dashboard</h2>
+      <app-settings *ngIf="selectedView === 'settings'"></app-settings>
+      <h2 *ngIf="selectedView === 'home'">Bienvenido al dashboard</h2>
     </main>
   </div>
 </div>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -11,6 +11,7 @@ export class DashboardComponent {
   menuOpen = false;
   submenus: Record<string, boolean> = {};
   subsubmenus: Record<string, boolean> = {};
+  selectedView = 'home';
 
   toggleMenu(): void {
     this.menuOpen = !this.menuOpen;
@@ -22,6 +23,11 @@ export class DashboardComponent {
 
   toggleSubsubmenu(key: string): void {
     this.subsubmenus[key] = !this.subsubmenus[key];
+  }
+
+  selectView(view: string): void {
+    this.selectedView = view;
+    this.menuOpen = false;
   }
 
   onLogout(): void {

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -1,0 +1,2 @@
+<h2>Configuración</h2>
+<p>Aquí irán las opciones de configuración.</p>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.css']
+})
+export class SettingsComponent {}


### PR DESCRIPTION
## Summary
- create SettingsComponent to display configuration options
- update DashboardComponent to load content dynamically
- add a menu item with a gear icon to open the settings view
- push the new menu item to the bottom of the sidebar

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b26a31fa8832d9778460e97147708