### PR TITLE
Improve settings menu UX

### DIFF
--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -125,3 +125,7 @@
 .bottom-item {
   margin-top: auto;
 }
+
+.sidemenu li.active .menu-item {
+  background: rgba(255, 255, 255, 0.2);
+}

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -47,7 +47,7 @@
             <li>Submenú 2-2</li>
           </ul>
         </li>
-        <li class="bottom-item" (click)="selectView('settings')">
+        <li class="bottom-item" (click)="selectView('settings')" [class.active]="selectedView === 'settings'">
           <div class="menu-item">
             <span class="icon">&#9881;</span>
             <span>Configuración</span>

--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -1,0 +1,5 @@
+.breadcrumb {
+  font-size: 0.85rem;
+  color: #888;
+  margin-bottom: 0.5rem;
+}

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -1,2 +1,3 @@
+<nav class="breadcrumb">Inicio / Configuración</nav>
 <h2>Configuración</h2>
 <p>Aquí irán las opciones de configuración.</p>


### PR DESCRIPTION
## Summary
- highlight active menu item in dashboard side menu
- show breadcrumb path for settings view

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b27e4cc8c832dbedc08edb1cba0e0