### PR TITLE
Apply login styles to settings form

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<div class="login-container" *ngIf="!isLoggedIn">
+<div class="login-container form-container" *ngIf="!isLoggedIn">
   <h1>Iniciar sesión</h1>
   <form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
     <div class="form-group">

--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -4,21 +4,3 @@
   margin-bottom: 0.5rem;
 }
 
-.menu-form {
-  max-width: 400px;
-}
-
-.form-group {
-  margin-bottom: 1rem;
-}
-
-.form-group label {
-  display: block;
-  margin-bottom: 0.25rem;
-}
-
-.form-group input {
-  width: 100%;
-  padding: 0.25rem;
-  box-sizing: border-box;
-}

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -1,6 +1,7 @@
 <nav class="breadcrumb">Inicio / Configuración</nav>
 <h2>Configuración</h2>
 
+<div class="form-container">
 <form [formGroup]="menuForm" (ngSubmit)="onSubmit()" class="menu-form">
   <h3>Agrega tu menú</h3>
 
@@ -23,5 +24,8 @@
     </datalist>
   </div>
 
-  <button type="submit">Guardar</button>
+  <div class="form-actions">
+    <button type="submit">Guardar</button>
+  </div>
 </form>
+</div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -29,3 +29,54 @@ textarea {
     background-color: #0e8a6e;
   }
 
+/* Estilos reutilizables para formularios basados en el login */
+.form-container {
+  max-width: 400px;
+  margin: 80px auto;
+  padding: 2rem;
+  background-color: #444654;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+  color: #e8e8e8;
+}
+
+.form-container form {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-container .form-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.form-container .form-actions {
+  display: flex;
+  justify-content: center;
+}
+
+.form-container label {
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.form-container input {
+  padding: 0.75rem;
+  border-radius: 4px;
+  border: 1px solid #565869;
+  background-color: #343541;
+  color: #fff;
+  width: 100%;
+}
+
+.form-container button {
+  margin-top: 0.5rem;
+  width: 100%;
+}
+
+.error {
+  color: #ff6b6b;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- create global `form-container` styles to reuse login theme
- use `form-container` class in login form
- wrap settings form in `form-container` and align buttons
- clean up unused settings styles

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b29802d68832dbc03524d90c6c1e7