### PR TITLE
Add dynamic menu management

### DIFF
--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -17,10 +17,15 @@
 
   <div class="form-group">
     <label for="parent">Menú padre</label>
-    <input id="parent" type="text" list="parentOptions" formControlName="parent" placeholder="Seleccione un menú padre" />
+    <input
+      id="parent"
+      type="text"
+      list="parentOptions"
+      formControlName="parent"
+      placeholder="Seleccione un menú padre"
+    />
     <datalist id="parentOptions">
-      <option value="Principal"></option>
-      <option value="Otro"></option>
+      <option *ngFor="let m of parentMenus" [value]="m.id">{{ m.name }}</option>
     </datalist>
   </div>
 
@@ -28,4 +33,20 @@
     <button type="submit">Guardar</button>
   </div>
 </form>
+
+  <div class="menu-tree" *ngIf="menuTree && menuTree.length">
+    <h3>Estructura de menús</h3>
+    <ng-template [ngTemplateOutlet]="tree" [ngTemplateOutletContext]="{ $implicit: menuTree }"></ng-template>
+  </div>
 </div>
+
+<ng-template #tree let-nodes>
+  <ul>
+    <li *ngFor="let node of nodes">
+      {{ node.name }}
+      <ng-container *ngIf="node.children && node.children.length">
+        <ng-template [ngTemplateOutlet]="tree" [ngTemplateOutletContext]="{ $implicit: node.children }"></ng-template>
+      </ng-container>
+    </li>
+  </ul>
+</ng-template>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,15 +1,19 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'app-settings',
   templateUrl: './settings.component.html',
   styleUrls: ['./settings.component.css']
 })
-export class SettingsComponent {
+export class SettingsComponent implements OnInit {
   menuForm: FormGroup;
+  parentMenus: any[] = [];
+  menuTree: any[] = [];
+  private ownerId = 1;
 
-  constructor(private fb: FormBuilder) {
+  constructor(private fb: FormBuilder, private http: HttpClient) {
     this.menuForm = this.fb.group({
       name: [''],
       url: [''],
@@ -17,7 +21,37 @@ export class SettingsComponent {
     });
   }
 
+  ngOnInit(): void {
+    this.loadParentMenus();
+    this.loadMenuTree();
+  }
+
+  loadParentMenus(): void {
+    this.http
+      .get<any[]>(`http://localhost:3000/menus/all?owner_id=${this.ownerId}`)
+      .subscribe((menus) => (this.parentMenus = menus));
+  }
+
+  loadMenuTree(): void {
+    this.http
+      .get<any[]>(`http://localhost:3000/menus?owner_id=${this.ownerId}`)
+      .subscribe((tree) => (this.menuTree = tree));
+  }
+
   onSubmit(): void {
-    console.log(this.menuForm.value);
+    const { name, url, parent } = this.menuForm.value;
+    const body = {
+      name,
+      path: url || null,
+      parent_id: parent || null,
+      owner_id: this.ownerId
+    };
+    this.http.post('http://localhost:3000/menus', body).subscribe({
+      next: () => {
+        this.menuForm.reset();
+        this.loadParentMenus();
+        this.loadMenuTree();
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- fetch parent menu options via API
- submit new menu and refresh parent options
- display menu hierarchy tree in settings view

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2b192858832d9b1f19f8430167ff