### PR TITLE
Fix menu requests with token

### DIFF
--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 @Component({
   selector: 'app-dashboard',
@@ -17,6 +17,11 @@ export class DashboardComponent implements OnInit {
 
   constructor(private http: HttpClient) {}
 
+  private getCookie(name: string): string | null {
+    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+    return match ? decodeURIComponent(match[2]) : null;
+  }
+
   toggleMenu(): void {
     this.menuOpen = !this.menuOpen;
   }
@@ -26,8 +31,10 @@ export class DashboardComponent implements OnInit {
   }
 
   loadMenuTree(): void {
+    const token = this.getCookie('token');
+    const options = token ? { headers: new HttpHeaders({ token }) } : {};
     this.http
-      .get<any[]>(`http://localhost:3000/menus?owner_id=${this.ownerId}`)
+      .get<any[]>(`http://localhost:3000/menus?owner_id=${this.ownerId}`, options)
       .subscribe((tree) => (this.menuTree = tree));
   }
 

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 @Component({
   selector: 'app-settings',
@@ -21,20 +21,29 @@ export class SettingsComponent implements OnInit {
     });
   }
 
+  private getCookie(name: string): string | null {
+    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+    return match ? decodeURIComponent(match[2]) : null;
+  }
+
   ngOnInit(): void {
     this.loadParentMenus();
     this.loadMenuTree();
   }
 
   loadParentMenus(): void {
+    const token = this.getCookie('token');
+    const options = token ? { headers: new HttpHeaders({ token }) } : {};
     this.http
-      .get<any[]>(`http://localhost:3000/menus/all?owner_id=${this.ownerId}`)
+      .get<any[]>(`http://localhost:3000/menus/all?owner_id=${this.ownerId}`, options)
       .subscribe((menus) => (this.parentMenus = menus));
   }
 
   loadMenuTree(): void {
+    const token = this.getCookie('token');
+    const options = token ? { headers: new HttpHeaders({ token }) } : {};
     this.http
-      .get<any[]>(`http://localhost:3000/menus?owner_id=${this.ownerId}`)
+      .get<any[]>(`http://localhost:3000/menus?owner_id=${this.ownerId}`, options)
       .subscribe((tree) => (this.menuTree = tree));
   }
 
@@ -46,7 +55,9 @@ export class SettingsComponent implements OnInit {
       parent_id: parent || null,
       owner_id: this.ownerId
     };
-    this.http.post('http://localhost:3000/menus', body).subscribe({
+    const token = this.getCookie('token');
+    const options = token ? { headers: new HttpHeaders({ token }) } : {};
+    this.http.post('http://localhost:3000/menus', body, options).subscribe({
       next: () => {
         this.menuForm.reset();
         this.loadParentMenus();


### PR DESCRIPTION
## Summary
- add cookie helper to Dashboard
- send auth token from Dashboard for menu service
- add cookie helper to Settings
- send auth token from Settings for menu service

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b2eab18d4832daeceb4b4d8cc1bae