### PR TITLE
Ensure JWT cookie is sent with requests

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -69,7 +69,9 @@ export class AppComponent implements OnInit {
 
   private performLogout(): void {
     const token = this.getCookie('token');
-    const options = token ? { headers: new HttpHeaders({ token }) } : {};
+    const options = token
+      ? { headers: new HttpHeaders({ token }), withCredentials: true }
+      : { withCredentials: true };
     this.http
       .post('http://localhost:3000/auth/logout', {}, options)
       .subscribe({
@@ -97,7 +99,8 @@ export class AppComponent implements OnInit {
     this.http
       .post<LoginResponse>(
         'http://localhost:3000/auth/login',
-        { username, password }
+        { username, password },
+        { withCredentials: true }
       )
       .subscribe({
         next: (res) => {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -32,9 +32,14 @@ export class DashboardComponent implements OnInit {
 
   loadMenuTree(): void {
     const token = this.getCookie('token');
-    const options = token ? { headers: new HttpHeaders({ token }) } : {};
+    const options = token
+      ? { headers: new HttpHeaders({ token }), withCredentials: true }
+      : { withCredentials: true };
     this.http
-      .get<any[]>(`http://localhost:3000/menus?owner_id=${this.ownerId}`, options)
+      .get<any[]>(
+        `http://localhost:3000/menus?owner_id=${this.ownerId}`,
+        options
+      )
       .subscribe((tree) => (this.menuTree = tree));
   }
 

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -33,17 +33,27 @@ export class SettingsComponent implements OnInit {
 
   loadParentMenus(): void {
     const token = this.getCookie('token');
-    const options = token ? { headers: new HttpHeaders({ token }) } : {};
+    const options = token
+      ? { headers: new HttpHeaders({ token }), withCredentials: true }
+      : { withCredentials: true };
     this.http
-      .get<any[]>(`http://localhost:3000/menus/all?owner_id=${this.ownerId}`, options)
+      .get<any[]>(
+        `http://localhost:3000/menus/all?owner_id=${this.ownerId}`,
+        options
+      )
       .subscribe((menus) => (this.parentMenus = menus));
   }
 
   loadMenuTree(): void {
     const token = this.getCookie('token');
-    const options = token ? { headers: new HttpHeaders({ token }) } : {};
+    const options = token
+      ? { headers: new HttpHeaders({ token }), withCredentials: true }
+      : { withCredentials: true };
     this.http
-      .get<any[]>(`http://localhost:3000/menus?owner_id=${this.ownerId}`, options)
+      .get<any[]>(
+        `http://localhost:3000/menus?owner_id=${this.ownerId}`,
+        options
+      )
       .subscribe((tree) => (this.menuTree = tree));
   }
 
@@ -56,7 +66,9 @@ export class SettingsComponent implements OnInit {
       owner_id: this.ownerId
     };
     const token = this.getCookie('token');
-    const options = token ? { headers: new HttpHeaders({ token }) } : {};
+    const options = token
+      ? { headers: new HttpHeaders({ token }), withCredentials: true }
+      : { withCredentials: true };
     this.http.post('http://localhost:3000/menus', body, options).subscribe({
       next: () => {
         this.menuForm.reset();


### PR DESCRIPTION
## Summary
- enable `withCredentials` in auth login/logout requests
- send cookies alongside header tokens in dashboard and settings

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_684b366dc8ac832db4ed38049ce55f16