### PR TITLE
Implement Material tree navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@angular/platform-browser-dynamic": "^16.2.0",
     "@angular/router": "^16.2.0",
     "@angular/service-worker": "^16.2.12",
+    "@angular/material": "^16.2.0",
+    "@angular/cdk": "^16.2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.13.0"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,10 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
+import { MatTreeModule } from '@angular/material/tree';
+import { MatIconModule } from '@angular/material/icon';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
@@ -9,7 +12,15 @@ import { SettingsComponent } from './settings/settings.component';
 
 @NgModule({
   declarations: [AppComponent, DashboardComponent, SettingsComponent],
-  imports: [BrowserModule, AppRoutingModule, ReactiveFormsModule, HttpClientModule],
+  imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
+    AppRoutingModule,
+    ReactiveFormsModule,
+    HttpClientModule,
+    MatTreeModule,
+    MatIconModule
+  ],
   providers: [],
   bootstrap: [AppComponent]
 })

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -8,11 +8,29 @@
   </header>
   <div class="body">
     <nav class="sidemenu" [class.open]="menuOpen">
+      <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
+        <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
+          <button mat-icon-button disabled></button>
+          {{ node.name }}
+        </mat-tree-node>
+        <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+          <div class="mat-tree-node">
+            <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'toggle ' + node.name">
+              <mat-icon>
+                {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
+              </mat-icon>
+            </button>
+            {{ node.name }}
+          </div>
+          <div [class.tree-children]="true">
+            <ng-container matTreeNodeOutlet></ng-container>
+          </div>
+        </mat-nested-tree-node>
+      </mat-tree>
       <ul>
-        <ng-template [ngTemplateOutlet]="tree" [ngTemplateOutletContext]="{ nodes: menuTree }"></ng-template>
         <li class="bottom-item" (click)="selectView('settings')" [class.active]="selectedView === 'settings'">
           <div class="menu-item">
-            <span class="icon">&#9881;</span>
+            <mat-icon class="icon">settings</mat-icon>
             <span>Configuración</span>
           </div>
         </li>
@@ -24,17 +42,3 @@
     </main>
   </div>
 </div>
-
-<ng-template #tree let-nodes>
-  <ng-container *ngFor="let node of nodes">
-    <li>
-      <div class="menu-item" (click)="toggleNode(node.id)">
-        <span>{{ node.name }}</span>
-        <span *ngIf="node.children && node.children.length" class="arrow" [class.open]="isOpen(node.id)">&#9654;</span>
-      </div>
-      <ul class="submenu" *ngIf="node.children && node.children.length" [class.open]="isOpen(node.id)">
-        <ng-template [ngTemplateOutlet]="tree" [ngTemplateOutletContext]="{ nodes: node.children }"></ng-template>
-      </ul>
-    </li>
-  </ng-container>
-</ng-template>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,17 +1,27 @@
 import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { NestedTreeControl } from '@angular/cdk/tree';
+import { MatTreeNestedDataSource } from '@angular/material/tree';
 
 @Component({
   selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css']
 })
+export interface MenuNode {
+  id: number;
+  name: string;
+  path?: string | null;
+  children?: MenuNode[];
+}
+
 export class DashboardComponent implements OnInit {
   @Input() user: { name: string; company: string } | null = null;
   @Output() logout = new EventEmitter<void>();
   menuOpen = false;
-  expanded: Record<number, boolean> = {};
-  menuTree: any[] = [];
+  menuTree: MenuNode[] = [];
+  treeControl = new NestedTreeControl<MenuNode>((node) => node.children);
+  dataSource = new MatTreeNestedDataSource<MenuNode>();
   private ownerId = 1;
   selectedView = 'home';
 
@@ -40,16 +50,14 @@ export class DashboardComponent implements OnInit {
         `http://localhost:3000/menus?owner_id=${this.ownerId}`,
         options
       )
-      .subscribe((tree) => (this.menuTree = tree));
+      .subscribe((tree) => {
+        this.menuTree = tree as MenuNode[];
+        this.dataSource.data = this.menuTree;
+      });
   }
 
-  toggleNode(id: number): void {
-    this.expanded[id] = !this.expanded[id];
-  }
-
-  isOpen(id: number): boolean {
-    return !!this.expanded[id];
-  }
+  hasChild = (_: number, node: MenuNode) =>
+    !!node.children && node.children.length > 0;
 
   selectView(view: string): void {
     this.selectedView = view;

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -36,23 +36,24 @@
 
   <div class="menu-tree" *ngIf="menuTree && menuTree.length">
     <h3>Estructura de menús</h3>
-    <ng-template
-      [ngTemplateOutlet]="tree"
-      [ngTemplateOutletContext]="{ nodes: menuTree }"
-    ></ng-template>
+    <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
+      <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
+        <button mat-icon-button disabled></button>
+        {{ node.name }}
+      </mat-tree-node>
+      <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+        <div class="mat-tree-node">
+          <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'toggle ' + node.name">
+            <mat-icon>
+              {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
+            </mat-icon>
+          </button>
+          {{ node.name }}
+        </div>
+        <div class="tree-children">
+          <ng-container matTreeNodeOutlet></ng-container>
+        </div>
+      </mat-nested-tree-node>
+    </mat-tree>
   </div>
 </div>
-
-<ng-template #tree let-nodes="nodes">
-  <ul>
-    <li *ngFor="let node of nodes">
-      {{ node.name }}
-      <ng-container *ngIf="node.children && node.children.length">
-        <ng-template
-          [ngTemplateOutlet]="tree"
-          [ngTemplateOutletContext]="{ nodes: node.children }"
-        ></ng-template>
-      </ng-container>
-    </li>
-  </ul>
-</ng-template>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,6 +1,15 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { NestedTreeControl } from '@angular/cdk/tree';
+import { MatTreeNestedDataSource } from '@angular/material/tree';
+
+export interface MenuNode {
+  id: number;
+  name: string;
+  path?: string | null;
+  children?: MenuNode[];
+}
 
 @Component({
   selector: 'app-settings',
@@ -10,7 +19,9 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 export class SettingsComponent implements OnInit {
   menuForm: FormGroup;
   parentMenus: any[] = [];
-  menuTree: any[] = [];
+  menuTree: MenuNode[] = [];
+  treeControl = new NestedTreeControl<MenuNode>((node) => node.children);
+  dataSource = new MatTreeNestedDataSource<MenuNode>();
   private ownerId = 1;
 
   constructor(private fb: FormBuilder, private http: HttpClient) {
@@ -54,8 +65,14 @@ export class SettingsComponent implements OnInit {
         `http://localhost:3000/menus?owner_id=${this.ownerId}`,
         options
       )
-      .subscribe((tree) => (this.menuTree = tree));
+      .subscribe((tree) => {
+        this.menuTree = tree as MenuNode[];
+        this.dataSource.data = this.menuTree;
+      });
   }
+
+  hasChild = (_: number, node: MenuNode) =>
+    !!node.children && node.children.length > 0;
 
   onSubmit(): void {
     const { name, url, parent } = this.menuForm.value;


### PR DESCRIPTION
## Summary
- add Angular Material dependencies
- register Material modules and animations
- replace custom menu tree with Angular Material tree in dashboard
- display menu structure with Material tree in settings

## Testing
- `npm test --silent -- -c` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b37feea5c832da58cf04cb4ccbd99