### PR TITLE
Fix indentation in menu tree

### DIFF
--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -17,12 +17,15 @@
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
-.menu-tree .mat-tree-node,
-.menu-tree .mat-nested-tree-node {
+.menu-tree .mat-tree-node {
   display: flex;
   align-items: center;
   font-size: 0.85rem;
   padding: 1px 0;
+}
+
+.menu-tree .mat-nested-tree-node {
+  display: block;
 }
 
 .menu-tree .mat-tree-node:hover,


### PR DESCRIPTION
## Summary
- correct flex styling for nested tree nodes so child menus appear indented below parents

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b40b8ad34832d9fbc21ebe4a511ff