### PR TITLE
Reduce spacing in menu tree

### DIFF
--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -22,6 +22,8 @@
   align-items: center;
   font-size: 0.85rem;
   padding: 1px 0;
+  min-height: 20px;
+  line-height: 20px;
 }
 
 .menu-tree .mat-nested-tree-node {


### PR DESCRIPTION
## Summary
- adjust spacing in menu tree nodes so they appear more compact

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b415a3be4832d99da0313d0eda45f