### PR TITLE
Reduce vertical spacing in menu tree

### DIFF
--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -21,9 +21,9 @@
   display: flex;
   align-items: center;
   font-size: 0.85rem;
-  padding: 1px 0;
-  min-height: 20px;
-  line-height: 20px;
+  padding: 0;
+  min-height: 14px;
+  line-height: 14px;
 }
 
 .menu-tree .mat-nested-tree-node {
@@ -48,8 +48,8 @@
   color: #c5c5c5;
 }
 .menu-tree mat-icon {
-  font-size: 16px;
-  line-height: 18px;
+  font-size: 14px;
+  line-height: 14px;
 }
 
 .tree-children {


### PR DESCRIPTION
## Summary
- tighten row height in the menu tree
- scale down node icon sizes

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b41ee6ed4832dbfd01c6f8b6ebcce