### PR TITLE
Fix tree spacing

### DIFF
--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -38,6 +38,9 @@
 .menu-tree button.mat-icon-button {
   width: 16px;
   height: 16px;
+  min-width: 16px;
+  line-height: 16px;
+  padding: 0;
   margin-right: 2px;
   color: inherit;
   flex-shrink: 0;
@@ -48,8 +51,10 @@
   color: #c5c5c5;
 }
 .menu-tree mat-icon {
+  width: 16px;
+  height: 16px;
   font-size: 14px;
-  line-height: 14px;
+  line-height: 16px;
 }
 
 .tree-children {


### PR DESCRIPTION
## Summary
- adjust menu tree icon/button sizes so lines are tighter

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b45b45e2c832db821c0bff32adfb7