### PR TITLE
Fix menu tree spacing

### DIFF
--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -5,7 +5,7 @@
 }
 
 /* VS Code like tree styling */
-.menu-tree {
+:host ::ng-deep .menu-tree {
   background-color: #1e1e1e;
   border: 1px solid #444;
   border-radius: 4px;
@@ -17,25 +17,25 @@
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
-.menu-tree .mat-tree-node {
+:host ::ng-deep .menu-tree .mat-tree-node {
   display: flex;
   align-items: center;
   font-size: 0.85rem;
   padding: 0;
-  min-height: 14px;
+  height: 14px;
   line-height: 14px;
 }
 
-.menu-tree .mat-nested-tree-node {
+:host ::ng-deep .menu-tree .mat-nested-tree-node {
   display: block;
 }
 
-.menu-tree .mat-tree-node:hover,
-.menu-tree .mat-nested-tree-node:hover {
+:host ::ng-deep .menu-tree .mat-tree-node:hover,
+:host ::ng-deep .menu-tree .mat-nested-tree-node:hover {
   background-color: rgba(255, 255, 255, 0.08);
 }
 
-.menu-tree button.mat-icon-button {
+:host ::ng-deep .menu-tree button.mat-icon-button {
   width: 16px;
   height: 16px;
   min-width: 16px;
@@ -46,24 +46,24 @@
   flex-shrink: 0;
 }
 
-.menu-tree .node-icon {
+:host ::ng-deep .menu-tree .node-icon {
   margin-right: 2px;
   color: #c5c5c5;
 }
-.menu-tree mat-icon {
+:host ::ng-deep .menu-tree mat-icon {
   width: 16px;
   height: 16px;
   font-size: 14px;
   line-height: 16px;
 }
 
-.tree-children {
+:host ::ng-deep .tree-children {
   margin-left: 16px;
   border-left: 1px dashed #555;
   padding-left: 4px;
 }
 
-.menu-tree h3 {
+:host ::ng-deep .menu-tree h3 {
   margin: 0 0 0.25rem 0;
   color: #d4d4d4;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- reduce line height of tree nodes in settings menu tree
- apply `:host ::ng-deep` overrides so styles affect angular material components

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4c83c134832d82b34e4a70384471