### PR TITLE
Reset menu tree styles

### DIFF
--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -1,70 +1,13 @@
+
 .breadcrumb {
   font-size: 0.85rem;
   color: #888;
   margin-bottom: 0.5rem;
 }
 
-/* VS Code like tree styling */
-:host ::ng-deep .menu-tree {
-  background-color: #1e1e1e;
-  border: 1px solid #444;
-  border-radius: 4px;
-  padding: 0.25rem;
-  margin-top: 0.5rem;
-  max-height: 400px;
-  overflow: auto;
-  color: #d4d4d4;
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-}
+/*
+ * Previously this component applied a custom "VS Code" style to the menu tree.
+ * Those rules have been removed so that the tree now relies on the default
+ * Angular Material appearance.
+ */
 
-:host ::ng-deep .menu-tree .mat-tree-node {
-  display: flex;
-  align-items: center;
-  font-size: 0.85rem;
-  padding: 0;
-  height: 14px;
-  line-height: 14px;
-}
-
-:host ::ng-deep .menu-tree .mat-nested-tree-node {
-  display: block;
-}
-
-:host ::ng-deep .menu-tree .mat-tree-node:hover,
-:host ::ng-deep .menu-tree .mat-nested-tree-node:hover {
-  background-color: rgba(255, 255, 255, 0.08);
-}
-
-:host ::ng-deep .menu-tree button.mat-icon-button {
-  width: 16px;
-  height: 16px;
-  min-width: 16px;
-  line-height: 16px;
-  padding: 0;
-  margin-right: 2px;
-  color: inherit;
-  flex-shrink: 0;
-}
-
-:host ::ng-deep .menu-tree .node-icon {
-  margin-right: 2px;
-  color: #c5c5c5;
-}
-:host ::ng-deep .menu-tree mat-icon {
-  width: 16px;
-  height: 16px;
-  font-size: 14px;
-  line-height: 16px;
-}
-
-:host ::ng-deep .tree-children {
-  margin-left: 16px;
-  border-left: 1px dashed #555;
-  padding-left: 4px;
-}
-
-:host ::ng-deep .menu-tree h3 {
-  margin: 0 0 0.25rem 0;
-  color: #d4d4d4;
-  font-weight: 600;
-}


### PR DESCRIPTION
## Summary
- remove the custom VS Code-like tree styling from the menu tree component

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b50a9c78c832da133fcb5c6a60697