### PR TITLE
Reset menu tree HTML for Material defaults

### DIFF
--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -39,7 +39,6 @@
     <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
       <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
         <button mat-icon-button disabled></button>
-        <mat-icon class="node-icon">insert_drive_file</mat-icon>
         {{ node.name }}
       </mat-tree-node>
       <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
@@ -53,12 +52,9 @@
               {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
             </mat-icon>
           </button>
-          <mat-icon class="node-icon">
-            {{ treeControl.isExpanded(node) ? 'folder_open' : 'folder' }}
-          </mat-icon>
           {{ node.name }}
         </div>
-        <div class="tree-children">
+        <div>
           <ng-container matTreeNodeOutlet></ng-container>
         </div>
       </mat-nested-tree-node>


### PR DESCRIPTION
## Summary
- remove leftover `mat-icon` nodes and custom classes from the menu tree below the settings form

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b522bf260832db0eb7bb758e52af9