### PR TITLE
Reset menu tree markup

### DIFF
--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -1,13 +1,6 @@
-
 .breadcrumb {
   font-size: 0.85rem;
   color: #888;
   margin-bottom: 0.5rem;
 }
-
-/*
- * Previously this component applied a custom "VS Code" style to the menu tree.
- * Those rules have been removed so that the tree now relies on the default
- * Angular Material appearance.
- */
 

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -34,34 +34,21 @@
   </div>
 </form>
 
-  <div class="menu-tree" *ngIf="menuTree && menuTree.length">
-    <h3>Estructura de menús</h3>
-    <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
-      <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
-        <button mat-icon-button disabled></button>
-        <mat-icon class="node-icon">insert_drive_file</mat-icon>
-        {{ node.name }}
-      </mat-tree-node>
-      <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
-        <div class="mat-tree-node">
-          <button
-            mat-icon-button
-            matTreeNodeToggle
-            [attr.aria-label]="'toggle ' + node.name"
-          >
-            <mat-icon>
-              {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
-            </mat-icon>
-          </button>
-          <mat-icon class="node-icon">
-            {{ treeControl.isExpanded(node) ? 'folder_open' : 'folder' }}
-          </mat-icon>
+    <div class="menu-tree" *ngIf="menuTree && menuTree.length">
+      <h3>Estructura de menús</h3>
+      <ul>
+        <ng-container *ngTemplateOutlet="renderNodes; context: { $implicit: menuTree }"></ng-container>
+      </ul>
+    </div>
+
+    <ng-template #renderNodes let-nodes>
+      <ng-container *ngFor="let node of nodes">
+        <li>
           {{ node.name }}
-        </div>
-        <div class="tree-children">
-          <ng-container matTreeNodeOutlet></ng-container>
-        </div>
-      </mat-nested-tree-node>
-    </mat-tree>
-  </div>
+          <ul *ngIf="node.children && node.children.length">
+            <ng-container *ngTemplateOutlet="renderNodes; context: { $implicit: node.children }"></ng-container>
+          </ul>
+        </li>
+      </ng-container>
+    </ng-template>
 </div>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { NestedTreeControl } from '@angular/cdk/tree';
-import { MatTreeNestedDataSource } from '@angular/material/tree';
 
 export interface MenuNode {
   id: number;
@@ -20,8 +18,6 @@ export class SettingsComponent implements OnInit {
   menuForm: FormGroup;
   parentMenus: any[] = [];
   menuTree: MenuNode[] = [];
-  treeControl = new NestedTreeControl<MenuNode>((node: MenuNode) => node.children);
-  dataSource = new MatTreeNestedDataSource<MenuNode>();
   private ownerId = 1;
 
   constructor(private fb: FormBuilder, private http: HttpClient) {
@@ -70,9 +66,6 @@ export class SettingsComponent implements OnInit {
         // return a flat list, so build the hierarchy if "children" are missing.
         const isFlat = tree.length && !tree.some((m) => Array.isArray(m.children));
         this.menuTree = isFlat ? this.buildTree(tree) : (tree as MenuNode[]);
-        this.dataSource.data = this.menuTree;
-        this.treeControl.dataNodes = this.menuTree;
-        this.treeControl.collapseAll();
       });
   }
 
@@ -87,8 +80,6 @@ export class SettingsComponent implements OnInit {
       }));
   }
 
-  hasChild = (_: number, node: MenuNode) =>
-    !!node.children && node.children.length > 0;
 
   onSubmit(): void {
     const { name, url, parent } = this.menuForm.value;


### PR DESCRIPTION
## Summary
- drop Angular Material tree from settings page
- show menu tree with plain nested lists

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b522bf260832db0eb7bb758e52af9