### PR TITLE
Reset menu tree with Material defaults

### DIFF
--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -33,21 +33,31 @@
     <button type="submit">Guardar</button>
   </div>
 </form>
-    <div class="menu-tree" *ngIf="menuTree && menuTree.length">
-      <h3>Estructura de menús</h3>
-      <ul>
-        <ng-container *ngTemplateOutlet="renderNodes; context: { $implicit: menuTree }"></ng-container>
-      </ul>
-    </div>
 
-    <ng-template #renderNodes let-nodes>
-      <ng-container *ngFor="let node of nodes">
-        <li>
+  <div class="menu-tree" *ngIf="menuTree && menuTree.length">
+    <h3>Estructura de menús</h3>
+    <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
+      <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
+        <button mat-icon-button disabled></button>
+        {{ node.name }}
+      </mat-tree-node>
+      <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+        <div class="mat-tree-node">
+          <button
+            mat-icon-button
+            matTreeNodeToggle
+            [attr.aria-label]="'toggle ' + node.name"
+          >
+            <mat-icon>
+              {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
+            </mat-icon>
+          </button>
           {{ node.name }}
-          <ul *ngIf="node.children && node.children.length">
-            <ng-container *ngTemplateOutlet="renderNodes; context: { $implicit: node.children }"></ng-container>
-          </ul>
-        </li>
-      </ng-container>
-    </ng-template>
+        </div>
+        <div>
+          <ng-container matTreeNodeOutlet></ng-container>
+        </div>
+      </mat-nested-tree-node>
+    </mat-tree>
+  </div>
 </div>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { NestedTreeControl } from '@angular/cdk/tree';
+import { MatTreeNestedDataSource } from '@angular/material/tree';
 
 export interface MenuNode {
   id: number;
@@ -18,6 +20,8 @@ export class SettingsComponent implements OnInit {
   menuForm: FormGroup;
   parentMenus: any[] = [];
   menuTree: MenuNode[] = [];
+  treeControl = new NestedTreeControl<MenuNode>((node: MenuNode) => node.children);
+  dataSource = new MatTreeNestedDataSource<MenuNode>();
   private ownerId = 1;
 
   constructor(private fb: FormBuilder, private http: HttpClient) {
@@ -66,6 +70,9 @@ export class SettingsComponent implements OnInit {
         // return a flat list, so build the hierarchy if "children" are missing.
         const isFlat = tree.length && !tree.some((m) => Array.isArray(m.children));
         this.menuTree = isFlat ? this.buildTree(tree) : (tree as MenuNode[]);
+        this.dataSource.data = this.menuTree;
+        this.treeControl.dataNodes = this.menuTree;
+        this.treeControl.collapseAll();
       });
   }
 
@@ -80,6 +87,8 @@ export class SettingsComponent implements OnInit {
       }));
   }
 
+  hasChild = (_: number, node: MenuNode) =>
+    !!node.children && node.children.length > 0;
 
   onSubmit(): void {
     const { name, url, parent } = this.menuForm.value;


### PR DESCRIPTION
## Summary
- restore Angular Material menu tree in settings
- reconnect data source and tree control

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b574654ac832d90bea444eb41be2e