### PR TITLE
Implement basic routing in dashboard

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,13 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { HomeComponent } from './home/home.component';
+import { SettingsComponent } from './settings/settings.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  { path: '', redirectTo: 'home', pathMatch: 'full' },
+  { path: 'home', component: HomeComponent },
+  { path: 'settings', component: SettingsComponent }
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,9 +10,10 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { SettingsComponent } from './settings/settings.component';
+import { HomeComponent } from './home/home.component';
 
 @NgModule({
-  declarations: [AppComponent, DashboardComponent, SettingsComponent],
+  declarations: [AppComponent, DashboardComponent, SettingsComponent, HomeComponent],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -11,7 +11,7 @@
       <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
         <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
           <button mat-icon-button disabled></button>
-          {{ node.name }}
+          <span (click)="navigateTo(node.path)" routerLinkActive="active" [routerLink]="node.path">{{ node.name }}</span>
         </mat-tree-node>
         <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
           <div class="mat-tree-node">
@@ -20,7 +20,7 @@
                 {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
               </mat-icon>
             </button>
-            {{ node.name }}
+            <span (click)="navigateTo(node.path)" routerLinkActive="active" [routerLink]="node.path">{{ node.name }}</span>
           </div>
           <div [class.tree-children]="true">
             <ng-container matTreeNodeOutlet></ng-container>
@@ -28,8 +28,8 @@
         </mat-nested-tree-node>
       </mat-tree>
       <ul>
-        <li class="bottom-item" (click)="selectView('settings')" [class.active]="selectedView === 'settings'">
-          <div class="menu-item">
+        <li class="bottom-item" routerLinkActive="active">
+          <div class="menu-item" [routerLink]="'settings'" (click)="menuOpen = false">
             <mat-icon class="icon">settings</mat-icon>
             <span>Configuración</span>
           </div>
@@ -37,8 +37,7 @@
       </ul>
     </nav>
     <main class="content">
-      <app-settings *ngIf="selectedView === 'settings'"></app-settings>
-      <h2 *ngIf="selectedView === 'home'">Bienvenido al dashboard</h2>
+      <router-outlet></router-outlet>
     </main>
   </div>
 </div>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { NestedTreeControl } from '@angular/cdk/tree';
 import { MatTreeNestedDataSource } from '@angular/material/tree';
@@ -24,9 +25,8 @@ export class DashboardComponent implements OnInit {
   treeControl = new NestedTreeControl<MenuNode>((node: MenuNode) => node.children);
   dataSource = new MatTreeNestedDataSource<MenuNode>();
   private ownerId = 1;
-  selectedView = 'home';
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private router: Router) {}
 
   private getCookie(name: string): string | null {
     const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
@@ -60,9 +60,11 @@ export class DashboardComponent implements OnInit {
   hasChild = (_: number, node: MenuNode) =>
     !!node.children && node.children.length > 0;
 
-  selectView(view: string): void {
-    this.selectedView = view;
-    this.menuOpen = false;
+  navigateTo(path: string | null | undefined): void {
+    if (path) {
+      this.router.navigate([path]);
+      this.menuOpen = false;
+    }
   }
 
   onLogout(): void {

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,0 +1,1 @@
+<h2>Bienvenido al dashboard</h2>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.css']
+})
+export class HomeComponent {}


### PR DESCRIPTION
## Summary
- define home and settings routes
- add HomeComponent as default view
- hook router outlet into dashboard
- navigate to routes from sidebar menu

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5a291384832d8b1fb59d9c14ea07