### PR TITLE
Implement basic routing in dashboard

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,13 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { HomeComponent } from './home/home.component';
+import { SettingsComponent } from './settings/settings.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  { path: '', redirectTo: 'home', pathMatch: 'full' },
+  { path: 'home', component: HomeComponent },
+  { path: 'settings', component: SettingsComponent }
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,25 +3,20 @@ import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
-import { MatTreeModule } from '@angular/material/tree';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { SettingsComponent } from './settings/settings.component';
+import { HomeComponent } from './home/home.component';
 
 @NgModule({
-  declarations: [AppComponent, DashboardComponent, SettingsComponent],
+  declarations: [AppComponent, DashboardComponent, SettingsComponent, HomeComponent],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
     AppRoutingModule,
     ReactiveFormsModule,
-    HttpClientModule,
-    MatTreeModule,
-    MatIconModule,
-    MatButtonModule
+    HttpClientModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -8,37 +8,39 @@
   </header>
   <div class="body">
     <nav class="sidemenu" [class.open]="menuOpen">
-      <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
-        <mat-tree-node *matTreeNodeDef="let node" matTreeNodePadding>
-          <button mat-icon-button disabled></button>
-          {{ node.name }}
-        </mat-tree-node>
-        <mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
-          <div class="mat-tree-node">
-            <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'toggle ' + node.name">
-              <mat-icon>
-                {{ treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right' }}
-              </mat-icon>
-            </button>
-            {{ node.name }}
-          </div>
-          <div [class.tree-children]="true">
-            <ng-container matTreeNodeOutlet></ng-container>
-          </div>
-        </mat-nested-tree-node>
-      </mat-tree>
       <ul>
-        <li class="bottom-item" (click)="selectView('settings')" [class.active]="selectedView === 'settings'">
-          <div class="menu-item">
-            <mat-icon class="icon">settings</mat-icon>
+        <ng-template [ngTemplateOutlet]="tree" [ngTemplateOutletContext]="{ nodes: menuTree }"></ng-template>
+        <li class="bottom-item" routerLinkActive="active">
+          <a class="menu-item" [routerLink]="'settings'" (click)="menuOpen = false">
+            <span class="icon">&#9881;</span>
             <span>Configuración</span>
-          </div>
+          </a>
         </li>
       </ul>
     </nav>
     <main class="content">
-      <app-settings *ngIf="selectedView === 'settings'"></app-settings>
-      <h2 *ngIf="selectedView === 'home'">Bienvenido al dashboard</h2>
+      <router-outlet></router-outlet>
     </main>
   </div>
 </div>
+
+<ng-template #tree let-nodes>
+  <ng-container *ngFor="let node of nodes">
+    <li [routerLinkActive]="'active'">
+      <ng-container *ngIf="node.children && node.children.length; else leaf">
+        <div class="menu-item" (click)="toggleNode(node.id)">
+          <span>{{ node.name }}</span>
+          <span class="arrow" [class.open]="isOpen(node.id)">&#9654;</span>
+        </div>
+        <ul class="submenu" [class.open]="isOpen(node.id)">
+          <ng-template [ngTemplateOutlet]="tree" [ngTemplateOutletContext]="{ nodes: node.children }"></ng-template>
+        </ul>
+      </ng-container>
+      <ng-template #leaf>
+        <a class="menu-item" (click)="navigateTo(node.path)">
+          <span>{{ node.name }}</span>
+        </a>
+      </ng-template>
+    </li>
+  </ng-container>
+</ng-template>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,7 +1,6 @@
 import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { NestedTreeControl } from '@angular/cdk/tree';
-import { MatTreeNestedDataSource } from '@angular/material/tree';
 
 export interface MenuNode {
   id: number;
@@ -21,12 +20,10 @@ export class DashboardComponent implements OnInit {
   @Output() logout = new EventEmitter<void>();
   menuOpen = false;
   menuTree: MenuNode[] = [];
-  treeControl = new NestedTreeControl<MenuNode>((node: MenuNode) => node.children);
-  dataSource = new MatTreeNestedDataSource<MenuNode>();
+  expanded: Record<number, boolean> = {};
   private ownerId = 1;
-  selectedView = 'home';
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private router: Router) {}
 
   private getCookie(name: string): string | null {
     const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
@@ -51,18 +48,57 @@ export class DashboardComponent implements OnInit {
         `http://localhost:3000/menus?owner_id=${this.ownerId}`,
         options
       )
-      .subscribe((tree) => {
-        this.menuTree = tree as MenuNode[];
-        this.dataSource.data = this.menuTree;
+      .subscribe({
+        next: (tree) => (this.menuTree = tree as MenuNode[]),
+        error: () => {
+          // Fallback sample menu when backend is unavailable
+          this.menuTree = [
+            { id: 1, name: 'Inicio', path: 'home' },
+            {
+              id: 2,
+              name: 'Módulos',
+              children: [
+                {
+                  id: 3,
+                  name: 'Ventas',
+                  path: 'ventas'
+                },
+                {
+                  id: 4,
+                  name: 'Inventario',
+                  children: [
+                    {
+                      id: 5,
+                      name: 'Productos',
+                      path: 'inventario/productos'
+                    },
+                    {
+                      id: 6,
+                      name: 'Bodegas',
+                      path: 'inventario/bodegas'
+                    }
+                  ]
+                }
+              ]
+            }
+          ];
+        }
       });
   }
 
-  hasChild = (_: number, node: MenuNode) =>
-    !!node.children && node.children.length > 0;
+  toggleNode(id: number): void {
+    this.expanded[id] = !this.expanded[id];
+  }
 
-  selectView(view: string): void {
-    this.selectedView = view;
-    this.menuOpen = false;
+  isOpen(id: number): boolean {
+    return !!this.expanded[id];
+  }
+
+  navigateTo(path: string | null | undefined): void {
+    if (path) {
+      this.router.navigate([path]);
+      this.menuOpen = false;
+    }
   }
 
   onLogout(): void {

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,0 +1,1 @@
+<h2>Bienvenido al dashboard</h2>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-home',
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.css']
+})
+export class HomeComponent {}


### PR DESCRIPTION
## Summary
- define home and settings routes
- add HomeComponent as default view
- hook router outlet into dashboard
- navigate to routes from sidebar menu
- switch menu tree to collapsible list
- provide example fallback menu tree when backend isn't reachable

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5a291384832d8b1fb59d9c14ea07