### PR TITLE
Remove Material tree from settings

### DIFF
--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { NestedTreeControl } from '@angular/cdk/tree';
-import { MatTreeNestedDataSource } from '@angular/material/tree';
 
 export interface MenuNode {
   id: number;
@@ -20,8 +18,6 @@ export class SettingsComponent implements OnInit {
   menuForm: FormGroup;
   parentMenus: any[] = [];
   menuTree: MenuNode[] = [];
-  treeControl = new NestedTreeControl<MenuNode>((node: MenuNode) => node.children);
-  dataSource = new MatTreeNestedDataSource<MenuNode>();
   private ownerId = 1;
 
   constructor(private fb: FormBuilder, private http: HttpClient) {
@@ -70,9 +66,6 @@ export class SettingsComponent implements OnInit {
         // return a flat list, so build the hierarchy if "children" are missing.
         const isFlat = tree.length && !tree.some((m) => Array.isArray(m.children));
         this.menuTree = isFlat ? this.buildTree(tree) : (tree as MenuNode[]);
-        this.dataSource.data = this.menuTree;
-        this.treeControl.dataNodes = this.menuTree;
-        this.treeControl.collapseAll();
       });
   }
 


### PR DESCRIPTION
## Summary
- drop Angular Material tree imports and properties from Settings component

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6d1d8484832db89ed6175c1fd40a