### PR TITLE
Add reusable CookieService

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,11 +2,13 @@ import { TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { AppComponent } from './app.component';
+import { CookieService } from './services/cookie.service';
 
 describe('AppComponent', () => {
   beforeEach(() => TestBed.configureTestingModule({
     declarations: [AppComponent],
     imports: [ReactiveFormsModule],
+    providers: [CookieService],
     schemas: [NO_ERRORS_SCHEMA]
   }));
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component, HostListener, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { CookieService } from './services/cookie.service';
 
 interface LoginResponse {
   message: string;
@@ -23,7 +24,7 @@ export class AppComponent implements OnInit {
   private inactivityTimeout: any;
 
   ngOnInit(): void {
-    const loginData = this.getCookie('loginData');
+    const loginData = this.cookieService.get('loginData');
     if (loginData) {
       try {
         const res: LoginResponse = JSON.parse(decodeURIComponent(loginData));
@@ -43,17 +44,13 @@ export class AppComponent implements OnInit {
     this.resetInactivityTimer();
   }
 
-  constructor(private fb: FormBuilder, private http: HttpClient) {
+  constructor(private fb: FormBuilder, private http: HttpClient, private cookieService: CookieService) {
     this.loginForm = this.fb.group({
       username: ['', [Validators.required, Validators.email]],
       password: ['', Validators.required]
     });
   }
 
-  private getCookie(name: string): string | null {
-    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
-    return match ? decodeURIComponent(match[2]) : null;
-  }
 
   private resetInactivityTimer(): void {
     if (!this.isLoggedIn) {
@@ -68,7 +65,7 @@ export class AppComponent implements OnInit {
   }
 
   private performLogout(): void {
-    const token = this.getCookie('token');
+    const token = this.cookieService.get('token');
     const options = token
       ? { headers: new HttpHeaders({ token }), withCredentials: true }
       : { withCredentials: true };

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { VentasComponent } from './ventas/ventas.component';
 import { ProductosComponent } from './productos/productos.component';
 import { BodegasComponent } from './bodegas/bodegas.component';
 import { SidebarComponent } from './sidebar/sidebar.component';
+import { CookieService } from './services/cookie.service';
 
 @NgModule({
   declarations: [
@@ -31,7 +32,7 @@ import { SidebarComponent } from './sidebar/sidebar.component';
     ReactiveFormsModule,
     HttpClientModule
   ],
-  providers: [],
+  providers: [CookieService],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/services/cookie.service.ts
+++ b/src/app/services/cookie.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class CookieService {
+  get(name: string): string | null {
+    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+    return match ? decodeURIComponent(match[2]) : null;
+  }
+
+  set(name: string, value: string, options: { path?: string; expires?: string | Date } = {}): void {
+    let cookie = `${name}=${encodeURIComponent(value)}`;
+    if (options.expires) {
+      const expires = options.expires instanceof Date
+        ? options.expires.toUTCString()
+        : options.expires;
+      cookie += `; expires=${expires}`;
+    }
+    cookie += `; path=${options.path ?? '/'}`;
+    document.cookie = cookie;
+  }
+
+  delete(name: string, path = '/'): void {
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=${path};`;
+  }
+}

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { CookieService } from '../services/cookie.service';
 import { NestedTreeControl } from '@angular/cdk/tree';
 import { MatTreeNestedDataSource } from '@angular/material/tree';
 
@@ -24,7 +25,7 @@ export class SettingsComponent implements OnInit {
   dataSource = new MatTreeNestedDataSource<MenuNode>();
   private ownerId = 1;
 
-  constructor(private fb: FormBuilder, private http: HttpClient) {
+  constructor(private fb: FormBuilder, private http: HttpClient, private cookieService: CookieService) {
     this.menuForm = this.fb.group({
       name: [''],
       url: [''],
@@ -32,10 +33,6 @@ export class SettingsComponent implements OnInit {
     });
   }
 
-  private getCookie(name: string): string | null {
-    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
-    return match ? decodeURIComponent(match[2]) : null;
-  }
 
   ngOnInit(): void {
     this.loadParentMenus();
@@ -43,7 +40,7 @@ export class SettingsComponent implements OnInit {
   }
 
   loadParentMenus(): void {
-    const token = this.getCookie('token');
+    const token = this.cookieService.get('token');
     const options = token
       ? { headers: new HttpHeaders({ token }), withCredentials: true }
       : { withCredentials: true };
@@ -56,7 +53,7 @@ export class SettingsComponent implements OnInit {
   }
 
   loadMenuTree(): void {
-    const token = this.getCookie('token');
+    const token = this.cookieService.get('token');
     const options = token
       ? { headers: new HttpHeaders({ token }), withCredentials: true }
       : { withCredentials: true };
@@ -98,7 +95,7 @@ export class SettingsComponent implements OnInit {
       parent_id: parent || null,
       owner_id: this.ownerId
     };
-    const token = this.getCookie('token');
+    const token = this.cookieService.get('token');
     const options = token
       ? { headers: new HttpHeaders({ token }), withCredentials: true }
       : { withCredentials: true };

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { CookieService } from '../services/cookie.service';
 
 export interface MenuNode {
   id: number;
@@ -21,19 +22,15 @@ export class SidebarComponent implements OnInit {
   expanded: Record<number, boolean> = {};
   private ownerId = 1;
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private cookieService: CookieService) {}
 
   ngOnInit(): void {
     this.loadMenuTree();
   }
 
-  private getCookie(name: string): string | null {
-    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
-    return match ? decodeURIComponent(match[2]) : null;
-  }
 
   loadMenuTree(): void {
-    const token = this.getCookie('token');
+    const token = this.cookieService.get('token');
     const options = token
       ? { headers: new HttpHeaders({ token }), withCredentials: true }
       : { withCredentials: true };


### PR DESCRIPTION
## Summary
- create `CookieService` for cookie get/set/delete operations
- inject `CookieService` into AppModule
- refactor AppComponent, SidebarComponent and SettingsComponent to use the new service
- fix AppComponent spec to provide CookieService

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6d1bdd60832d85fd9735d695ea51