### PR TITLE
Implement persistent, responsive sidebar

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,6 +1,12 @@
 <div class="dashboard">
   <header class="topbar">
-    <button class="hamburger" (click)="toggleMenu()">&#9776;</button>
+    <button
+      class="hamburger"
+      (click)="toggleMenu()"
+      [attr.aria-expanded]="menuOpen"
+    >
+      &#9776;
+    </button>
     <div class="userinfo" *ngIf="user">
       {{ user.name }} - {{ user.company }}
     </div>
@@ -8,7 +14,7 @@
   </header>
   <div class="body">
     <app-sidebar [open]="menuOpen" (closeMenu)="menuOpen = false"></app-sidebar>
-    <main class="content" [style.marginLeft.px]="menuOpen ? 220 : 0">
+    <main class="content" [style.marginLeft.px]="menuOpen && isDesktop ? 220 : 0">
       <router-outlet></router-outlet>
     </main>
   </div>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -10,14 +10,28 @@ export class DashboardComponent {
   @Input() user: { name: string; company: string } | null = null;
   @Output() logout = new EventEmitter<void>();
   menuOpen = false;
+  private savedMenuState = true;
+  isDesktop = window.innerWidth >= 768;
+
+  ngOnInit(): void {
+    const stored = localStorage.getItem('sidebarOpen');
+    this.savedMenuState = stored !== null ? stored === 'true' : true;
+    this.menuOpen = this.isDesktop ? this.savedMenuState : false;
+  }
+
+  @HostListener('window:resize')
+  onResize(): void {
+    this.isDesktop = window.innerWidth >= 768;
+    this.menuOpen = this.isDesktop ? this.savedMenuState : false;
+  }
 
   constructor() {}
 
   toggleMenu(): void {
-    this.menuOpen = !this.menuOpen;
+    this.savedMenuState = !this.savedMenuState;
+    this.menuOpen = this.savedMenuState;
+    localStorage.setItem('sidebarOpen', String(this.savedMenuState));
   }
-
-
 
   onLogout(): void {
     this.logout.emit();

--- a/src/app/sidebar/sidebar.component.css
+++ b/src/app/sidebar/sidebar.component.css
@@ -12,6 +12,7 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  z-index: 1000;
 }
 
 .sidemenu.open {
@@ -45,6 +46,16 @@
   transition: background 0.2s ease;
 }
 
+button.menu-item {
+  background: none;
+  border: none;
+  width: 100%;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  padding: 0.75rem 1rem;
+}
+
 .menu-item:hover {
   background: rgba(255, 255, 255, 0.1);
 }
@@ -76,6 +87,12 @@
 
 .submenu .submenu li {
   padding-left: 2.5rem;
+}
+
+@media (min-width: 768px) {
+  .sidemenu {
+    position: fixed;
+  }
 }
 
 .bottom-item {

--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -1,7 +1,11 @@
 <nav class="sidemenu" [class.open]="open">
   <ul>
     <ng-template [ngTemplateOutlet]="tree" [ngTemplateOutletContext]="{ nodes: menuTree }"></ng-template>
-    <li class="bottom-item" routerLinkActive="active">
+    <li
+      class="bottom-item"
+      routerLinkActive="active"
+      [routerLinkActiveOptions]="{ exact: false }"
+    >
       <a class="menu-item" [routerLink]="'settings'" (click)="onSelect()">
         <span class="icon">&#9881;</span>
         <span>Configuración</span>
@@ -12,12 +16,17 @@
 
 <ng-template #tree let-nodes>
   <ng-container *ngFor="let node of nodes">
-    <li [routerLinkActive]="'active'">
+    <li [routerLinkActive]="'active'" [routerLinkActiveOptions]="{ exact: false }">
       <ng-container *ngIf="node.children && node.children.length; else leaf">
-        <div class="menu-item" (click)="toggleNode(node.id)">
+        <button
+          type="button"
+          class="menu-item"
+          (click)="toggleNode(node.id)"
+          [attr.aria-expanded]="isOpen(node.id)"
+        >
           <span>{{ node.name }}</span>
           <span class="arrow" [class.open]="isOpen(node.id)">&#9654;</span>
-        </div>
+        </button>
         <ul class="submenu" [class.open]="isOpen(node.id)">
           <ng-template [ngTemplateOutlet]="tree" [ngTemplateOutletContext]="{ nodes: node.children }"></ng-template>
         </ul>

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -26,6 +26,14 @@ export class SidebarComponent implements OnInit {
   constructor(private http: HttpClient, private cookieService: CookieService) {}
 
   ngOnInit(): void {
+    const stored = localStorage.getItem('menuExpanded');
+    if (stored) {
+      try {
+        this.expanded = JSON.parse(stored);
+      } catch (_) {
+        this.expanded = {};
+      }
+    }
     this.loadMenuTree();
   }
 
@@ -65,6 +73,7 @@ export class SidebarComponent implements OnInit {
 
   toggleNode(id: number): void {
     this.expanded[id] = !this.expanded[id];
+    localStorage.setItem('menuExpanded', JSON.stringify(this.expanded));
   }
 
   isOpen(id: number): boolean {


### PR DESCRIPTION
## Summary
- make sidebar hamburger button accessible
- persist sidebar open state and handle responsive resizing
- persist submenu expanded state in localStorage
- style sidebar toggle buttons
- fix sidebar position for desktop

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b725da82c832d8f9b9c0296d2ac56