### PR TITLE
Fix missing HostListener import

### DIFF
--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, HostListener } from '@angular/core';
 
 @Component({
   selector: 'app-dashboard',


### PR DESCRIPTION
## Summary
- add `HostListener` to dashboard component import

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b854a0c74832d85476d250cfb08f4