### PR TITLE
Add keyboard navigation and link handling in sidebar

### DIFF
--- a/src/app/sidebar/sidebar.component.css
+++ b/src/app/sidebar/sidebar.component.css
@@ -46,14 +46,26 @@
   transition: background 0.2s ease;
 }
 
-button.menu-item {
+
+.name-btn {
   background: none;
   border: none;
-  width: 100%;
-  text-align: left;
   color: inherit;
   font: inherit;
-  padding: 0.75rem 1rem;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  flex: 1;
+  text-align: left;
+}
+
+.arrow-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  padding: 0 0.25rem;
+  cursor: pointer;
 }
 
 .menu-item:hover {

--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -1,11 +1,10 @@
 <nav class="sidemenu" [class.open]="open">
   <ul>
-    <ng-template [ngTemplateOutlet]="tree" [ngTemplateOutletContext]="{ nodes: menuTree }"></ng-template>
-    <li
-      class="bottom-item"
-      routerLinkActive="active"
-      [routerLinkActiveOptions]="{ exact: false }"
-    >
+  <ng-template
+    [ngTemplateOutlet]="tree"
+    [ngTemplateOutletContext]="{ nodes: menuTree }"
+  ></ng-template>
+    <li class="bottom-item" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: false }">
       <a class="menu-item" [routerLink]="'settings'" (click)="onSelect()">
         <span class="icon">&#9881;</span>
         <span>Configuración</span>
@@ -17,25 +16,41 @@
 <ng-template #tree let-nodes>
   <ng-container *ngFor="let node of nodes">
     <li [routerLinkActive]="'active'" [routerLinkActiveOptions]="{ exact: false }">
-      <ng-container *ngIf="node.children && node.children.length; else leaf">
+      <div class="menu-item">
+        <ng-container *ngIf="node.path; else nameOnly">
+          <a
+            [routerLink]="node.path"
+            (click)="onSelect()"
+            (keydown)="onKeydown($event, node)"
+          >
+            {{ node.name }}
+          </a>
+        </ng-container>
+        <ng-template #nameOnly>
+          <button
+            type="button"
+            class="name-btn"
+            (click)="toggleNode(node.id)"
+            (keydown)="onKeydown($event, node)"
+            [attr.aria-expanded]="isOpen(node.id)"
+          >
+            {{ node.name }}
+          </button>
+        </ng-template>
         <button
+          *ngIf="node.children && node.children.length"
+          class="arrow-btn"
           type="button"
-          class="menu-item"
-          (click)="toggleNode(node.id)"
+          (click)="toggleNode(node.id); $event.stopPropagation()"
+          (keydown)="onKeydown($event, node)"
           [attr.aria-expanded]="isOpen(node.id)"
         >
-          <span>{{ node.name }}</span>
           <span class="arrow" [class.open]="isOpen(node.id)">&#9654;</span>
         </button>
-        <ul class="submenu" [class.open]="isOpen(node.id)">
-          <ng-template [ngTemplateOutlet]="tree" [ngTemplateOutletContext]="{ nodes: node.children }"></ng-template>
-        </ul>
-      </ng-container>
-      <ng-template #leaf>
-        <a class="menu-item" [routerLink]="node.path" (click)="onSelect()">
-          <span>{{ node.name }}</span>
-        </a>
-      </ng-template>
+      </div>
+      <ul *ngIf="node.children && node.children.length" class="submenu" [class.open]="isOpen(node.id)">
+        <ng-template [ngTemplateOutlet]="tree" [ngTemplateOutletContext]="{ nodes: node.children }"></ng-template>
+      </ul>
     </li>
   </ng-container>
 </ng-template>

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -83,4 +83,22 @@ export class SidebarComponent implements OnInit {
   onSelect(): void {
     this.closeMenu.emit();
   }
+
+  onKeydown(event: KeyboardEvent, node: MenuNode): void {
+    const hasChildren = !!node.children && node.children.length > 0;
+    if (event.key === 'Enter' || event.key === ' ') {
+      if (!node.path) {
+        event.preventDefault();
+        if (hasChildren) {
+          this.toggleNode(node.id);
+        }
+      }
+    } else if (event.key === 'ArrowRight' && hasChildren && !this.isOpen(node.id)) {
+      event.preventDefault();
+      this.toggleNode(node.id);
+    } else if (event.key === 'ArrowLeft' && hasChildren && this.isOpen(node.id)) {
+      event.preventDefault();
+      this.toggleNode(node.id);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- update sidebar menu handling to navigate when `path` is defined
- keep submenu state and allow expanding/collapsing via arrow buttons
- add keyboard navigation support (Enter/Space, Arrow keys)
- style new arrow and name buttons

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: ng not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find module '@angular/core')*

------
https://chatgpt.com/codex/tasks/task_e_684b86b6aeec832d86830e670c36a790