### PR TITLE
Inject CookieService in sidebar tests

### DIFF
--- a/src/app/sidebar/sidebar.component.spec.ts
+++ b/src/app/sidebar/sidebar.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { CookieService } from '../services/cookie.service';
 
 import { SidebarComponent } from './sidebar.component';
 
@@ -14,6 +15,7 @@ describe('SidebarComponent', () => {
     TestBed.configureTestingModule({
       declarations: [SidebarComponent],
       imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [CookieService],
       schemas: [NO_ERRORS_SCHEMA]
     });
 
@@ -27,7 +29,7 @@ describe('SidebarComponent', () => {
   });
 
   it('should load fallback menu tree on http error', () => {
-    spyOn<any>(component, 'getCookie').and.returnValue(null);
+    spyOn(TestBed.inject(CookieService), 'get').and.returnValue(null);
 
     fixture.detectChanges();
 


### PR DESCRIPTION
## Summary
- update `sidebar.component.spec.ts` to use `CookieService`
- spy on `CookieService.get` instead of missing `getCookie` method
- provide `CookieService` in the test module

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8b2d9e70832d9ad518edded19d90