### PR TITLE
Use loginData cookie for ownerId

### DIFF
--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -22,7 +22,7 @@ export class SettingsComponent implements OnInit {
   menuForm: FormGroup;
   parentMenus: any[] = [];
   menuTree: MenuNode[] = [];
-  private ownerId = 1;
+  private ownerId!: number;
 
   constructor(private fb: FormBuilder, private http: HttpClient, private cookieService: CookieService) {
     this.menuForm = this.fb.group({
@@ -34,6 +34,16 @@ export class SettingsComponent implements OnInit {
 
 
   ngOnInit(): void {
+    const loginData = this.cookieService.get('loginData');
+    if (loginData) {
+      try {
+        const data = JSON.parse(loginData);
+        this.ownerId = data.ownerCompany.id;
+      } catch (_) {
+        // ignore parse errors
+      }
+    }
+
     this.loadParentMenus();
     this.loadMenuTree();
   }

--- a/src/app/sidebar/sidebar.component.spec.ts
+++ b/src/app/sidebar/sidebar.component.spec.ts
@@ -4,6 +4,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { SidebarComponent } from './sidebar.component';
+import { CookieService } from '../services/cookie.service';
 
 describe('SidebarComponent', () => {
   let component: SidebarComponent;
@@ -14,6 +15,7 @@ describe('SidebarComponent', () => {
     TestBed.configureTestingModule({
       declarations: [SidebarComponent],
       imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [CookieService],
       schemas: [NO_ERRORS_SCHEMA]
     });
 
@@ -27,7 +29,13 @@ describe('SidebarComponent', () => {
   });
 
   it('should load fallback menu tree on http error', () => {
-    spyOn<any>(component, 'getCookie').and.returnValue(null);
+    const cookieService = TestBed.inject(CookieService);
+    spyOn(cookieService, 'get').and.callFake((name: string) => {
+      if (name === 'loginData') {
+        return JSON.stringify({ ownerCompany: { id: 1 } });
+      }
+      return null;
+    });
 
     fixture.detectChanges();
 

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -21,11 +21,21 @@ export class SidebarComponent implements OnInit {
 
   menuTree: MenuNode[] = [];
   expanded: Record<number, boolean> = {};
-  private ownerId = 1;
+  private ownerId!: number;
 
   constructor(private http: HttpClient, private cookieService: CookieService) {}
 
   ngOnInit(): void {
+    const loginData = this.cookieService.get('loginData');
+    if (loginData) {
+      try {
+        const data = JSON.parse(loginData);
+        this.ownerId = data.ownerCompany.id;
+      } catch (_) {
+        // ignore parse errors
+      }
+    }
+
     const stored = localStorage.getItem('menuExpanded');
     if (stored) {
       try {


### PR DESCRIPTION
## Summary
- parse the `loginData` cookie to determine `ownerId` in sidebar/settings components
- update sidebar unit test for new cookie logic

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8b2ac704832d82b1354650cd88bb