### PR TITLE
Refactor menu retrieval into service

### DIFF
--- a/src/app/services/menu.service.ts
+++ b/src/app/services/menu.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { CookieService } from './cookie.service';
+import { environment } from '../../environments/environment';
+
+export interface MenuNode {
+  id: number;
+  name: string;
+  path?: string | null;
+  children?: MenuNode[];
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MenuService {
+  private readonly fallbackMenu: MenuNode[] = [
+    { id: 1, name: 'Inicio', path: 'home' },
+    {
+      id: 2,
+      name: 'Módulos',
+      children: [
+        { id: 3, name: 'Ventas', path: 'ventas' },
+        {
+          id: 4,
+          name: 'Inventario',
+          children: [
+            { id: 5, name: 'Productos', path: 'inventario/productos' },
+            { id: 6, name: 'Bodegas', path: 'inventario/bodegas' }
+          ]
+        }
+      ]
+    }
+  ];
+
+  constructor(private http: HttpClient, private cookieService: CookieService) {}
+
+  private httpOptions() {
+    const token = this.cookieService.get('token');
+    return token
+      ? { headers: new HttpHeaders({ token }), withCredentials: true }
+      : { withCredentials: true };
+  }
+
+  getParentMenus(ownerId: number): Observable<any[]> {
+    return this.http.get<any[]>(
+      `${environment.apiUrl}/menus/all?owner_id=${ownerId}`,
+      this.httpOptions()
+    );
+  }
+
+  getMenuTree(ownerId: number): Observable<MenuNode[]> {
+    return this.http
+      .get<any[]>(`${environment.apiUrl}/menus?owner_id=${ownerId}`, this.httpOptions())
+      .pipe(
+        map(tree => {
+          const isFlat = tree.length && !tree.some(m => Array.isArray(m.children));
+          return isFlat ? this.buildTree(tree) : (tree as MenuNode[]);
+        }),
+        catchError(() => of(this.fallbackMenu))
+      );
+  }
+
+  private buildTree(items: any[], parentId: number | null = null): MenuNode[] {
+    return items
+      .filter(m => m.parent_id === parentId)
+      .map(m => ({
+        id: m.id,
+        name: m.name,
+        path: m.path,
+        children: this.buildTree(items, m.id)
+      }));
+  }
+}

--- a/src/app/sidebar/sidebar.component.spec.ts
+++ b/src/app/sidebar/sidebar.component.spec.ts
@@ -1,40 +1,31 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { MenuService } from '../services/menu.service';
 
 import { SidebarComponent } from './sidebar.component';
 
 describe('SidebarComponent', () => {
   let component: SidebarComponent;
   let fixture: ComponentFixture<SidebarComponent>;
-  let httpMock: HttpTestingController;
+  let menuServiceSpy: jasmine.SpyObj<MenuService>;
 
   beforeEach(() => {
+    menuServiceSpy = jasmine.createSpyObj('MenuService', ['getMenuTree']);
     TestBed.configureTestingModule({
       declarations: [SidebarComponent],
-      imports: [HttpClientTestingModule, RouterTestingModule],
+      imports: [RouterTestingModule],
+      providers: [{ provide: MenuService, useValue: menuServiceSpy }],
       schemas: [NO_ERRORS_SCHEMA]
     });
 
     fixture = TestBed.createComponent(SidebarComponent);
     component = fixture.componentInstance;
-    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  afterEach(() => {
-    httpMock.verify();
-  });
-
-  it('should load fallback menu tree on http error', () => {
-    spyOn<any>(component, 'getCookie').and.returnValue(null);
-
-    fixture.detectChanges();
-
-    const req = httpMock.expectOne('http://localhost:3000/menus?owner_id=1');
-    req.error(new ErrorEvent('Network error'));
-
-    expect(component.menuTree).toEqual([
+  it('should load menu tree from service', () => {
+    const menu = [
       { id: 1, name: 'Inicio', path: 'home' },
       {
         id: 2,
@@ -51,7 +42,12 @@ describe('SidebarComponent', () => {
           }
         ]
       }
-    ]);
+    ];
+    menuServiceSpy.getMenuTree.and.returnValue(of(menu));
+
+    fixture.detectChanges();
+
+    expect(component.menuTree).toEqual(menu);
   });
 
   it('should toggle node open state', () => {


### PR DESCRIPTION
## Summary
- add `MenuService` providing menu tree retrieval with fallback handling
- inject `MenuService` into sidebar and settings components
- simplify sidebar spec to mock `MenuService`

## Testing
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8b270dc4832da89271801cf39f80