### PR TITLE
Fix cookie service injection

### DIFF
--- a/src/app/sidebar/sidebar.component.spec.ts
+++ b/src/app/sidebar/sidebar.component.spec.ts
@@ -17,7 +17,7 @@ describe('SidebarComponent', () => {
     TestBed.configureTestingModule({
       declarations: [SidebarComponent],
       imports: [RouterTestingModule],
-      providers: [{ provide: MenuService, useValue: menuServiceSpy }],
+      providers: [CookieService, { provide: MenuService, useValue: menuServiceSpy }],
       schemas: [NO_ERRORS_SCHEMA]
     });
 

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MenuService, MenuNode } from '../services/menu.service';
+import { CookieService } from '../services/cookie.service';
 
 @Component({
   selector: 'app-sidebar',
@@ -14,7 +15,10 @@ export class SidebarComponent implements OnInit {
   expanded: Record<number, boolean> = {};
   private ownerId!: number;
 
-  constructor(private menuService: MenuService) {}
+  constructor(
+    private menuService: MenuService,
+    private cookieService: CookieService
+  ) {}
 
   ngOnInit(): void {
     const loginData = this.cookieService.get('loginData');


### PR DESCRIPTION
## Summary
- inject `CookieService` into `SidebarComponent`
- provide `CookieService` in sidebar tests

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b8cdd9a14832d87eeaf9174a9394b