### PR TITLE
Handle invalid owner ID before loading menus

### DIFF
--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -37,14 +37,24 @@ export class SettingsComponent implements OnInit {
     if (loginData) {
       try {
         const data = JSON.parse(loginData);
-        this.ownerId = parseInt(data.ownerCompany.id, 10);
+        const parsedId = parseInt(data.ownerCompany.id, 10);
+        if (!isNaN(parsedId)) {
+          this.ownerId = parsedId;
+        }
       } catch (_) {
         // ignore parse errors
       }
     }
 
-    this.loadParentMenus();
-    this.loadMenuTree();
+    const hasValidOwner =
+      typeof this.ownerId === 'number' && !isNaN(this.ownerId);
+
+    if (hasValidOwner) {
+      this.loadParentMenus();
+      this.loadMenuTree();
+    } else {
+      console.warn('SettingsComponent: ownerId could not be determined');
+    }
   }
 
   loadParentMenus(): void {
@@ -77,8 +87,12 @@ export class SettingsComponent implements OnInit {
     this.http.post(`${environment.apiUrl}/menus`, body, options).subscribe({
       next: () => {
         this.menuForm.reset();
-        this.loadParentMenus();
-        this.loadMenuTree();
+        if (typeof this.ownerId === 'number' && !isNaN(this.ownerId)) {
+          this.loadParentMenus();
+          this.loadMenuTree();
+        } else {
+          console.warn('SettingsComponent: ownerId could not be determined');
+        }
       }
     });
   }

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -25,12 +25,18 @@ export class SidebarComponent implements OnInit {
     if (loginData) {
       try {
         const data = JSON.parse(loginData);
-        this.ownerId = parseInt(data.ownerCompany.id, 10);
+        const parsedId = parseInt(data.ownerCompany.id, 10);
+        if (!isNaN(parsedId)) {
+          this.ownerId = parsedId;
+        }
       } catch (_) {
         // ignore parse errors
       }
     }
 
+    const hasValidOwner =
+      typeof this.ownerId === 'number' && !isNaN(this.ownerId);
+    
     const stored = localStorage.getItem('menuExpanded');
     if (stored) {
       try {
@@ -39,7 +45,12 @@ export class SidebarComponent implements OnInit {
         this.expanded = {};
       }
     }
-    this.loadMenuTree();
+
+    if (hasValidOwner) {
+      this.loadMenuTree();
+    } else {
+      console.warn('SidebarComponent: ownerId could not be determined');
+    }
   }
 
 


### PR DESCRIPTION
## Summary
- validate ownerId from cookies before using it
- log a warning if ownerId is missing
- avoid loading menus when ownerId is invalid

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba3ca30ac832d9a62463837de1667