### PR TITLE
Implement collapsible menu tree

### DIFF
--- a/src/app/settings/settings.component.css
+++ b/src/app/settings/settings.component.css
@@ -4,3 +4,30 @@
   margin-bottom: 0.5rem;
 }
 
+.menu-tree ul {
+  list-style: none;
+  padding-left: 1rem;
+}
+
+.node {
+  display: flex;
+  align-items: center;
+}
+
+.toggle-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0 0.25rem 0 0;
+}
+
+.arrow {
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.arrow.open {
+  transform: rotate(90deg);
+}
+

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -36,7 +36,7 @@
 
   <div class="menu-tree" *ngIf="menuTree && menuTree.length">
     <h3>Estructura de menús</h3>
-    <ul>
+    <ul class="tree-root">
       <ng-container
         *ngTemplateOutlet="renderNodes; context: { $implicit: menuTree }"
       ></ng-container>
@@ -46,8 +46,22 @@
   <ng-template #renderNodes let-nodes>
     <ng-container *ngFor="let node of nodes">
       <li>
-        {{ node.name }}
-        <ul *ngIf="node.children && node.children.length">
+        <div class="node">
+          <button
+            *ngIf="node.children && node.children.length"
+            class="toggle-btn"
+            type="button"
+            (click)="toggleNode(node.id)"
+            [attr.aria-expanded]="isOpen(node.id)"
+          >
+            <span class="arrow" [class.open]="isOpen(node.id)">&#9656;</span>
+          </button>
+          <span>{{ node.name }}</span>
+        </div>
+        <ul
+          class="children"
+          *ngIf="node.children && node.children.length && isOpen(node.id)"
+        >
           <ng-container
             *ngTemplateOutlet="renderNodes; context: { $implicit: node.children }"
           ></ng-container>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -16,6 +16,7 @@ export class SettingsComponent implements OnInit {
   menuForm: FormGroup;
   parentMenus: any[] = [];
   menuTree: MenuNode[] = [];
+  expanded: Record<number, boolean> = {};
   private ownerId!: number;
 
   constructor(
@@ -63,7 +64,29 @@ export class SettingsComponent implements OnInit {
   loadMenuTree(): void {
     this.menuService
       .getMenuTree(this.ownerId)
-      .subscribe((tree) => (this.menuTree = tree));
+      .subscribe((tree) => {
+        this.menuTree = tree;
+        this.initExpanded(tree);
+      });
+  }
+
+  private initExpanded(nodes: MenuNode[]): void {
+    nodes.forEach(node => {
+      if (node.children && node.children.length) {
+        if (this.expanded[node.id] === undefined) {
+          this.expanded[node.id] = true;
+        }
+        this.initExpanded(node.children);
+      }
+    });
+  }
+
+  toggleNode(id: number): void {
+    this.expanded[id] = !this.expanded[id];
+  }
+
+  isOpen(id: number): boolean {
+    return !!this.expanded[id];
   }
 
   hasChild = (_: number, node: MenuNode) =>

--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -42,7 +42,7 @@
             (click)="toggleNode(node.id)"
             [attr.aria-expanded]="isOpen(node.id)"
           >
-            <span class="arrow" [class.open]="isOpen(node.id)">&#9654;</span>
+            <span class="arrow" [class.open]="isOpen(node.id)">&#9656;</span>
           </button>
         </div>
         <ul


### PR DESCRIPTION
## Summary
- update the sidebar arrow icon to a minimal triangle
- allow the settings menu tree to collapse/expand
- add basic styles for the collapsible tree

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba69901c8832db4292db54d1529cb