### PR TITLE
Fix sidebar collapse toggle

### DIFF
--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -47,7 +47,7 @@
         </div>
         <ul
           class="submenu"
-          *ngIf="node.children && node.children.length"
+          *ngIf="node.children && node.children.length && isOpen(node.id)"
           [class.open]="isOpen(node.id)"
         >
           <ng-container


### PR DESCRIPTION
## Summary
- ensure child nodes hide when collapsed in sidebar tree

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba7550300832db9ccdde1e32054ea