### PR TITLE
Agregar listado de materiales con paginación

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ import { SettingsComponent } from './settings/settings.component';
 import { VentasComponent } from './ventas/ventas.component';
 import { ProductosComponent } from './productos/productos.component';
 import { BodegasComponent } from './bodegas/bodegas.component';
+import { ListadoMaterialesComponent } from './listado-materiales/listado-materiales.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
@@ -12,6 +13,7 @@ const routes: Routes = [
   { path: 'ventas', component: VentasComponent },
   { path: 'inventario/productos', component: ProductosComponent },
   { path: 'inventario/bodegas', component: BodegasComponent },
+  { path: 'listado_materiales', component: ListadoMaterialesComponent },
   { path: 'settings', component: SettingsComponent }
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -12,6 +12,7 @@ import { VentasComponent } from './ventas/ventas.component';
 import { ProductosComponent } from './productos/productos.component';
 import { BodegasComponent } from './bodegas/bodegas.component';
 import { SidebarComponent } from './sidebar/sidebar.component';
+import { ListadoMaterialesComponent } from './listado-materiales/listado-materiales.component';
 import { CookieService } from './services/cookie.service';
 
 @NgModule({
@@ -23,13 +24,15 @@ import { CookieService } from './services/cookie.service';
     VentasComponent,
     ProductosComponent,
     BodegasComponent,
-    SidebarComponent
+    SidebarComponent,
+    ListadoMaterialesComponent
   ],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
     AppRoutingModule,
     ReactiveFormsModule,
+    FormsModule,
     HttpClientModule
   ],
   providers: [CookieService],

--- a/src/app/listado-materiales/listado-materiales.component.css
+++ b/src/app/listado-materiales/listado-materiales.component.css
@@ -1,0 +1,22 @@
+.controls {
+  margin-bottom: 1rem;
+}
+
+.materials-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.materials-table th,
+.materials-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+}
+
+.paginator {
+  margin-top: 1rem;
+}
+
+.paginator button.active {
+  font-weight: bold;
+}

--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -1,0 +1,28 @@
+<h2>Listado de materiales</h2>
+<div class="controls">
+  <label for="pageSize">Elementos por página:</label>
+  <select id="pageSize" [(ngModel)]="pageSize" (ngModelChange)="changePageSize($event)">
+    <option *ngFor="let size of [10,20,30,40,50]" [value]="size">{{ size }}</option>
+  </select>
+</div>
+<table class="materials-table">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Nombre</th>
+      <th>Descripción</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let material of paginatedItems">
+      <td>{{ material.id }}</td>
+      <td>{{ material.nombre }}</td>
+      <td>{{ material.descripcion }}</td>
+    </tr>
+  </tbody>
+</table>
+<div class="paginator" *ngIf="totalPages > 1">
+  <button (click)="goToPage(currentPage - 1)" [disabled]="currentPage === 1">Anterior</button>
+  <button *ngFor="let page of [].constructor(totalPages); let i = index" (click)="goToPage(i+1)" [class.active]="currentPage === i+1">{{ i + 1 }}</button>
+  <button (click)="goToPage(currentPage + 1)" [disabled]="currentPage === totalPages">Siguiente</button>
+</div>

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+
+interface Material {
+  id: number;
+  nombre: string;
+  descripcion: string;
+}
+
+@Component({
+  selector: 'app-listado-materiales',
+  templateUrl: './listado-materiales.component.html',
+  styleUrls: ['./listado-materiales.component.css']
+})
+export class ListadoMaterialesComponent {
+  materiales: Material[] = [];
+  pageSize = 10;
+  currentPage = 1;
+
+  constructor() {
+    this.materiales = Array.from({ length: 100 }).map((_, i) => ({
+      id: i + 1,
+      nombre: `Material ${i + 1}`,
+      descripcion: `Descripción del material ${i + 1}`
+    }));
+  }
+
+  get totalPages(): number {
+    return Math.ceil(this.materiales.length / this.pageSize);
+  }
+
+  get paginatedItems(): Material[] {
+    const start = (this.currentPage - 1) * this.pageSize;
+    return this.materiales.slice(start, start + this.pageSize);
+  }
+
+  changePageSize(size: number): void {
+    this.pageSize = size;
+    this.currentPage = 1;
+  }
+
+  goToPage(page: number): void {
+    if (page >= 1 && page <= this.totalPages) {
+      this.currentPage = page;
+    }
+  }
+}

--- a/src/app/services/menu.service.ts
+++ b/src/app/services/menu.service.ts
@@ -28,7 +28,8 @@ export class MenuService {
           name: 'Inventario',
           children: [
             { id: 5, name: 'Productos', path: 'inventario/productos' },
-            { id: 6, name: 'Bodegas', path: 'inventario/bodegas' }
+            { id: 6, name: 'Bodegas', path: 'inventario/bodegas' },
+            { id: 7, name: 'Materiales', path: 'listado_materiales' }
           ]
         }
       ]

--- a/src/app/sidebar/sidebar.component.spec.ts
+++ b/src/app/sidebar/sidebar.component.spec.ts
@@ -37,7 +37,8 @@ describe('SidebarComponent', () => {
             name: 'Inventario',
             children: [
               { id: 5, name: 'Productos', path: 'inventario/productos' },
-              { id: 6, name: 'Bodegas', path: 'inventario/bodegas' }
+              { id: 6, name: 'Bodegas', path: 'inventario/bodegas' },
+              { id: 7, name: 'Materiales', path: 'listado_materiales' }
             ]
           }
         ]


### PR DESCRIPTION
## Summary
- crear componente **ListadoMaterialesComponent** con tabla y paginador
- agregar la ruta `listado_materiales`
- declarar el componente y `FormsModule` en `AppModule`
- extender el menú de ejemplo para mostrar "Materiales"
- actualizar la prueba del sidebar

## Testing
- `npm test` *(falla: `ng` no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_684ba8698680832dae9398f09d5d24ab