### PR TITLE
Fix sidebar toggling and close behavior

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -13,7 +13,7 @@
     <button class="logout" (click)="onLogout()">Cerrar sesión</button>
   </header>
   <div class="body">
-    <app-sidebar [open]="menuOpen" (closeMenu)="menuOpen = false"></app-sidebar>
+    <app-sidebar [open]="menuOpen"></app-sidebar>
     <main class="content" [style.marginLeft.px]="menuOpen && isDesktop ? 220 : 0">
       <router-outlet></router-outlet>
     </main>

--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -4,7 +4,7 @@
       *ngTemplateOutlet="renderNodes; context: { $implicit: menuTree }"
     ></ng-container>
     <li class="bottom-item" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: false }">
-      <a class="menu-item" [routerLink]="'settings'" (click)="onSelect()">
+      <a class="menu-item" [routerLink]="'settings'">
         <span class="icon">&#9881;</span>
         <span>Configuración</span>
       </a>
@@ -16,7 +16,6 @@
       <li routerLinkActive="active" [routerLinkActiveOptions]="{ exact: false }">
         <div
           class="menu-item"
-          (click)="node.children && toggleNode(node.id)"
           (keydown)="onKeydown($event, node)"
           tabindex="0"
           [attr.aria-expanded]="node.children ? isOpen(node.id) : null"
@@ -25,7 +24,7 @@
             *ngIf="node.path"
             class="name-btn"
             [routerLink]="node.path"
-            (click)="onSelect()"
+            
             >{{ node.name }}</a
           >
           <button

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { MenuService, MenuNode } from '../services/menu.service';
 import { CookieService } from '../services/cookie.service';
 
@@ -9,7 +9,6 @@ import { CookieService } from '../services/cookie.service';
 })
 export class SidebarComponent implements OnInit {
   @Input() open = false;
-  @Output() closeMenu = new EventEmitter<void>();
 
   menuTree: MenuNode[] = [];
   expanded: Record<number, boolean> = {};
@@ -64,10 +63,6 @@ export class SidebarComponent implements OnInit {
 
   isOpen(id: number): boolean {
     return !!this.expanded[id];
-  }
-
-  onSelect(): void {
-    this.closeMenu.emit();
   }
 
   onKeydown(event: KeyboardEvent, node: MenuNode): void {


### PR DESCRIPTION
## Summary
- stop sidebar from closing when selecting menu items
- only toggle submenus when arrow button is clicked

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684baa327618832db5fb638cef462266