### PR TITLE
Fix sidebar node toggle area

### DIFF
--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -17,6 +17,7 @@
         <div
           class="menu-item"
           (keydown)="onKeydown($event, node)"
+          (click)="onItemClick(node, $event)"
           tabindex="0"
           [attr.aria-expanded]="node.children ? isOpen(node.id) : null"
         >
@@ -31,7 +32,6 @@
             *ngIf="!node.path"
             class="name-btn"
             type="button"
-            (click)="$event.stopPropagation()"
           >
             {{ node.name }}
           </button>

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -65,6 +65,14 @@ export class SidebarComponent implements OnInit {
     return !!this.expanded[id];
   }
 
+  onItemClick(node: MenuNode, event: MouseEvent): void {
+    const hasChildren = !!node.children && node.children.length > 0;
+    if (hasChildren && !node.path) {
+      this.toggleNode(node.id);
+      event.stopPropagation();
+    }
+  }
+
   onKeydown(event: KeyboardEvent, node: MenuNode): void {
     const hasChildren = !!node.children && node.children.length > 0;
     if (event.key === 'Enter' || event.key === ' ') {


### PR DESCRIPTION
## Summary
- enable toggling sidebar nodes by clicking anywhere on the menu item
- expose helper to toggle nodes on item click

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bab0fc71c832d96c0637c66d920b4