### PR TITLE
Fix sidebar submenu toggle for all nodes

### DIFF
--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -67,7 +67,10 @@ export class SidebarComponent implements OnInit {
 
   onItemClick(node: MenuNode, event: MouseEvent): void {
     const hasChildren = !!node.children && node.children.length > 0;
-    if (hasChildren && !node.path) {
+    if (hasChildren) {
+      if (node.path) {
+        event.preventDefault();
+      }
       this.toggleNode(node.id);
       event.stopPropagation();
     }


### PR DESCRIPTION
## Summary
- adjust `onItemClick` so all menu nodes with children toggle when clicked

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684babc8e160832da8eab4269f82af0e