### PR TITLE
Use backend pagination for materials list

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -19,7 +19,7 @@
     </tr>
   </thead>
   <tbody>
-    <tr *ngFor="let material of paginatedItems">
+    <tr *ngFor="let material of filteredItems">
       <td>{{ material.id }}</td>
       <td>{{ material.nombre }}</td>
       <td>{{ material.descripcion }}</td>

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -1,39 +1,33 @@
-import { Component } from '@angular/core';
-
-interface Material {
-  id: number;
-  nombre: string;
-  descripcion: string;
-}
+import { Component, OnInit } from '@angular/core';
+import { MaterialService, Material } from '../services/material.service';
 
 @Component({
   selector: 'app-listado-materiales',
   templateUrl: './listado-materiales.component.html',
   styleUrls: ['./listado-materiales.component.css']
 })
-export class ListadoMaterialesComponent {
+export class ListadoMaterialesComponent implements OnInit {
   materiales: Material[] = [];
   pageSize = 10;
   currentPage = 1;
+  totalPages = 1;
   filterId = '';
   filterNombre = '';
   filterDescripcion = '';
 
-  constructor() {
-    this.materiales = Array.from({ length: 100 }).map((_, i) => ({
-      id: i + 1,
-      nombre: `Material ${i + 1}`,
-      descripcion: `Descripción del material ${i + 1}`
-    }));
+  constructor(private materialService: MaterialService) {}
+
+  ngOnInit(): void {
+    this.loadMaterials();
   }
 
-  get totalPages(): number {
-    return Math.ceil(this.filteredItems.length / this.pageSize);
-  }
-
-  get paginatedItems(): Material[] {
-    const start = (this.currentPage - 1) * this.pageSize;
-    return this.filteredItems.slice(start, start + this.pageSize);
+  private loadMaterials(): void {
+    this.materialService
+      .getMaterials(this.currentPage, this.pageSize)
+      .subscribe(res => {
+        this.materiales = res.docs;
+        this.totalPages = res.totalPages;
+      });
   }
 
   get filteredItems(): Material[] {
@@ -47,15 +41,17 @@ export class ListadoMaterialesComponent {
   changePageSize(size: number): void {
     this.pageSize = size;
     this.currentPage = 1;
+    this.loadMaterials();
   }
 
   goToPage(page: number): void {
     if (page >= 1 && page <= this.totalPages) {
       this.currentPage = page;
+      this.loadMaterials();
     }
   }
 
   onFilterChange(): void {
-    this.currentPage = 1;
+    // Filtering is done client-side on the current page only
   }
 }

--- a/src/app/services/material.service.ts
+++ b/src/app/services/material.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { CookieService } from './cookie.service';
+import { environment } from '../../environments/environment';
+
+export interface Material {
+  id: number;
+  nombre: string;
+  descripcion: string;
+}
+
+export interface PaginatedMaterials {
+  docs: Material[];
+  totalDocs: number;
+  limit: number;
+  page: number;
+  totalPages: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MaterialService {
+  constructor(private http: HttpClient, private cookieService: CookieService) {}
+
+  private httpOptions() {
+    const token = this.cookieService.get('token');
+    return token
+      ? { headers: new HttpHeaders({ token }), withCredentials: true }
+      : { withCredentials: true };
+  }
+
+  getMaterials(page: number, limit: number): Observable<PaginatedMaterials> {
+    return this.http.get<PaginatedMaterials>(
+      `${environment.apiUrl}/materials?page=${page}&limit=${limit}`,
+      this.httpOptions()
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- pull materials from the `/materials` API
- provide MaterialService for API communication
- hook list component to endpoint-based pagination

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run build --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684baf230724832db36591f42e98e9f3