### PR TITLE
Handle material load errors

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -1,4 +1,5 @@
 <h2>Listado de materiales</h2>
+<div class="error" *ngIf="errorMessage">{{ errorMessage }}</div>
 <div class="controls">
   <label for="pageSize">Elementos por página:</label>
   <select id="pageSize" [(ngModel)]="pageSize" (ngModelChange)="changePageSize($event)">

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -14,6 +14,7 @@ export class ListadoMaterialesComponent implements OnInit {
   filterId = '';
   filterNombre = '';
   filterDescripcion = '';
+  errorMessage = '';
 
   constructor(private materialService: MaterialService) {}
 
@@ -22,11 +23,18 @@ export class ListadoMaterialesComponent implements OnInit {
   }
 
   private loadMaterials(): void {
+    this.errorMessage = '';
     this.materialService
       .getMaterials(this.currentPage, this.pageSize)
-      .subscribe(res => {
-        this.materiales = res.docs;
-        this.totalPages = res.totalPages;
+      .subscribe({
+        next: res => {
+          this.materiales = res.docs;
+          this.totalPages = res.totalPages;
+        },
+        error: err => {
+          console.error('Failed to load materials', err);
+          this.errorMessage = 'Error al cargar los materiales';
+        }
       });
   }
 


### PR DESCRIPTION
## Summary
- show an error message when materials fail to load
- log failure details in the console

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb1a95ac8832d922113f44cb90598