### PR TITLE
Update materials table fields

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -12,11 +12,19 @@
       <th>ID</th>
       <th>Nombre</th>
       <th>Descripción</th>
+      <th>Espesor (mm)</th>
+      <th>Ancho (m)</th>
+      <th>Largo (m)</th>
+      <th>Precio</th>
     </tr>
     <tr>
       <th><input class="filter-input" type="text" [(ngModel)]="filterId" (ngModelChange)="onFilterChange()" placeholder="Filtrar" /></th>
       <th><input class="filter-input" type="text" [(ngModel)]="filterNombre" (ngModelChange)="onFilterChange()" placeholder="Filtrar" /></th>
       <th><input class="filter-input" type="text" [(ngModel)]="filterDescripcion" (ngModelChange)="onFilterChange()" placeholder="Filtrar" /></th>
+      <th></th>
+      <th></th>
+      <th></th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
@@ -24,6 +32,10 @@
       <td>{{ material.id }}</td>
       <td>{{ material.name }}</td>
       <td>{{ material.description }}</td>
+      <td>{{ material.thickness_mm }}</td>
+      <td>{{ material.width_m }}</td>
+      <td>{{ material.length_m }}</td>
+      <td>{{ material.price }}</td>
     </tr>
   </tbody>
 </table>

--- a/src/app/services/material.service.ts
+++ b/src/app/services/material.service.ts
@@ -8,6 +8,13 @@ export interface Material {
   id: number;
   name: string;
   description: string;
+  thickness_mm?: number;
+  width_m?: number;
+  length_m?: number;
+  price?: number;
+  created_at?: string;
+  updated_at?: string;
+  owner_id?: number;
 }
 
 export interface PaginatedMaterials {


### PR DESCRIPTION
## Summary
- expose additional fields from `Material` interface
- display thickness, width, length and price in materials table

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb2d6d2b4832dad664e861537c2c7