### PR TITLE
Add materials table view

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.css
+++ b/src/app/listado-materiales/listado-materiales.component.css
@@ -1,0 +1,15 @@
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+th,
+td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}
+
+th {
+  background-color: #444654;
+}

--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -1,3 +1,27 @@
 <h2>Listado de materiales</h2>
 <div class="error" *ngIf="errorMessage">{{ errorMessage }}</div>
 <pre>{{ responseJson | json }}</pre>
+<table *ngIf="responseJson?.docs?.length">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Nombre</th>
+      <th>Descripción</th>
+      <th>Espesor (mm)</th>
+      <th>Ancho (m)</th>
+      <th>Largo (m)</th>
+      <th>Precio</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let item of responseJson.docs">
+      <td>{{ item.id }}</td>
+      <td>{{ item.name }}</td>
+      <td>{{ item.description }}</td>
+      <td>{{ item.thickness_mm }}</td>
+      <td>{{ item.width_m }}</td>
+      <td>{{ item.length_m }}</td>
+      <td>{{ item.price }}</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
## Summary
- render materials JSON in a table
- add basic table styling

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb46b591c832d8ce31301fcaf4cd7