### PR TITLE
Fix materials table rendering

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -1,7 +1,7 @@
 <h2>Listado de materiales</h2>
 <div class="error" *ngIf="errorMessage">{{ errorMessage }}</div>
 <pre>{{ responseJson | json }}</pre>
-<table *ngIf="responseJson?.docs?.length">
+<table *ngIf="materiales?.length">
   <thead>
     <tr>
       <th>ID</th>
@@ -14,7 +14,7 @@
     </tr>
   </thead>
   <tbody>
-    <tr *ngFor="let item of responseJson.docs">
+    <tr *ngFor="let item of materiales">
       <td>{{ item.id }}</td>
       <td>{{ item.name }}</td>
       <td>{{ item.description }}</td>

--- a/src/app/listado-materiales/listado-materiales.component.spec.ts
+++ b/src/app/listado-materiales/listado-materiales.component.spec.ts
@@ -48,8 +48,8 @@ describe('ListadoMaterialesComponent', () => {
 
     req.flush({ items: [] });
 
-    expect(component.materiales).toBeUndefined();
-    expect(component.totalPages).toBeUndefined();
+    expect(component.materiales).toEqual([]);
+    expect(component.totalPages).toBe(1);
   });
 
   it('should keep defaults on http error', () => {

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -29,8 +29,9 @@ export class ListadoMaterialesComponent implements OnInit {
       .getMaterials(this.currentPage, this.pageSize)
       .subscribe({
         next: res => {
-          this.materiales = res.docs;
-          this.totalPages = res.totalPages;
+          const docs: any = (res as any).docs ?? (res as any).items ?? res;
+          this.materiales = Array.isArray(docs) ? docs : [];
+          this.totalPages = (res as any).totalPages ?? 1;
           this.responseJson = res;
         },
         error: err => {


### PR DESCRIPTION
## Summary
- handle variable API response shapes in `loadMaterials`
- show table using `materiales` array in template
- update unit test expectation for mismatched fields

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb51c30a0832d94976e21ac3c6109