### PR TITLE
Fix client-side paging when API ignores limit

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -29,8 +29,24 @@ export class ListadoMaterialesComponent implements OnInit {
       .subscribe({
         next: res => {
           const docs: any = (res as any).docs ?? (res as any).items ?? res;
-          this.materiales = Array.isArray(docs) ? docs : [];
-          this.totalPages = (res as any).totalPages ?? 1;
+          const materials = Array.isArray(docs) ? docs : [];
+
+          // Determinar el total de páginas. Si la API no proporciona el valor o
+          // no respeta el límite solicitado, lo calculamos a partir del número
+          // de elementos recibido.
+          const apiTotalPages = (res as any).totalPages;
+          const apiTotalDocs = (res as any).totalDocs ?? materials.length;
+          const calculatedTotal = Math.ceil(apiTotalDocs / this.pageSize) || 1;
+          this.totalPages = apiTotalPages && apiTotalPages > 0
+            ? apiTotalPages
+            : calculatedTotal;
+
+          // En caso de que la API devuelva todos los elementos sin paginar,
+          // mostramos sólo los correspondientes a la página actual para que el
+          // usuario pueda paginar correctamente.
+          const start = (this.currentPage - 1) * this.pageSize;
+          const end = start + this.pageSize;
+          this.materiales = materials.slice(start, end);
         },
         error: err => {
           console.error('Failed to load materials', err);


### PR DESCRIPTION
## Summary
- ensure material list respects page size even if API returns all records

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bb8b3c634832daa8d4b02a824e63f