### PR TITLE
Fix paginator when API omits pagination info

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.spec.ts
+++ b/src/app/listado-materiales/listado-materiales.component.spec.ts
@@ -31,7 +31,7 @@ describe('ListadoMaterialesComponent', () => {
   it('should load materials with valid response', () => {
     (component as any).loadMaterials();
 
-    const req = httpMock.expectOne(`${environment.apiUrl}/materials?page=1&limit=10`);
+    const req = httpMock.expectOne(`${environment.apiUrl}/materials`);
     expect(req.request.method).toBe('GET');
 
     const materials = [{ id: 1, name: 'Mat1', description: 'Desc1' }];
@@ -43,7 +43,7 @@ describe('ListadoMaterialesComponent', () => {
 
   it('should handle mismatched fields', () => {
     (component as any).loadMaterials();
-    const req = httpMock.expectOne(`${environment.apiUrl}/materials?page=1&limit=10`);
+    const req = httpMock.expectOne(`${environment.apiUrl}/materials`);
     expect(req.request.method).toBe('GET');
 
     req.flush({ items: [] });
@@ -54,7 +54,7 @@ describe('ListadoMaterialesComponent', () => {
 
   it('should keep defaults on http error', () => {
     (component as any).loadMaterials();
-    const req = httpMock.expectOne(`${environment.apiUrl}/materials?page=1&limit=10`);
+    const req = httpMock.expectOne(`${environment.apiUrl}/materials`);
     expect(req.request.method).toBe('GET');
 
     try {

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -25,7 +25,7 @@ export class ListadoMaterialesComponent implements OnInit {
   private loadMaterials(): void {
     this.errorMessage = '';
     this.materialService
-      .getMaterials(this.currentPage, this.pageSize)
+      .getMaterials()
       .subscribe({
         next: res => {
           const docs: any = (res as any).docs ?? (res as any).items ?? res;

--- a/src/app/services/material.service.ts
+++ b/src/app/services/material.service.ts
@@ -38,10 +38,18 @@ export class MaterialService {
       : { withCredentials: true };
   }
 
-  getMaterials(page: number, limit: number): Observable<PaginatedMaterials> {
-    return this.http.get<PaginatedMaterials>(
-      `${environment.apiUrl}/materials?page=${page}&limit=${limit}`,
-      this.httpOptions()
-    );
+  getMaterials(page?: number, limit?: number): Observable<PaginatedMaterials> {
+    let url = `${environment.apiUrl}/materials`;
+    const params: string[] = [];
+    if (page !== undefined) {
+      params.push(`page=${page}`);
+    }
+    if (limit !== undefined) {
+      params.push(`limit=${limit}`);
+    }
+    if (params.length) {
+      url += `?${params.join('&')}`;
+    }
+    return this.http.get<PaginatedMaterials>(url, this.httpOptions());
   }
 }


### PR DESCRIPTION
## Summary
- fetch materials without page/limit so we get the full list
- build pagination on the client side
- allow optional page/limit parameters in the service
- adjust unit tests for new request URL

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bbc56d54c832d8fea90ba37d493b7