### PR TITLE
Remove pagination from materials list

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.css
+++ b/src/app/listado-materiales/listado-materiales.component.css
@@ -14,11 +14,4 @@ th {
   background-color: #444654;
 }
 
-.pagination {
-  margin-top: 1rem;
-}
-
-.pagination button {
-  margin: 0 2px;
-}
 

--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -24,10 +24,3 @@
     </tr>
   </tbody>
 </table>
-<div class="pagination" *ngIf="totalPages > 1">
-  <button (click)="goToPage(currentPage - 1)" [disabled]="currentPage === 1">Anterior</button>
-  <button *ngFor="let page of pages" (click)="goToPage(page)" [disabled]="currentPage === page">
-    {{ page }}
-  </button>
-  <button (click)="goToPage(currentPage + 1)" [disabled]="currentPage === totalPages">Siguiente</button>
-</div>

--- a/src/app/listado-materiales/listado-materiales.component.spec.ts
+++ b/src/app/listado-materiales/listado-materiales.component.spec.ts
@@ -38,7 +38,6 @@ describe('ListadoMaterialesComponent', () => {
     req.flush({ docs: materials, totalPages: 5 });
 
     expect(component.materiales).toEqual(materials);
-    expect(component.totalPages).toBe(5);
   });
 
   it('should handle mismatched fields', () => {
@@ -49,7 +48,6 @@ describe('ListadoMaterialesComponent', () => {
     req.flush({ items: [] });
 
     expect(component.materiales).toEqual([]);
-    expect(component.totalPages).toBe(1);
   });
 
   it('should keep defaults on http error', () => {
@@ -62,6 +60,5 @@ describe('ListadoMaterialesComponent', () => {
     } catch {}
 
     expect(component.materiales).toEqual([]);
-    expect(component.totalPages).toBe(1);
   });
 });

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -8,9 +8,6 @@ import { MaterialService, Material } from '../services/material.service';
 })
 export class ListadoMaterialesComponent implements OnInit {
   materiales: Material[] = [];
-  pageSize = 10;
-  currentPage = 1;
-  totalPages = 1;
   filterId = '';
   filterNombre = '';
   filterDescripcion = '';
@@ -29,24 +26,7 @@ export class ListadoMaterialesComponent implements OnInit {
       .subscribe({
         next: res => {
           const docs: any = (res as any).docs ?? (res as any).items ?? res;
-          const materials = Array.isArray(docs) ? docs : [];
-
-          // Determinar el total de páginas. Si la API no proporciona el valor o
-          // no respeta el límite solicitado, lo calculamos a partir del número
-          // de elementos recibido.
-          const apiTotalPages = (res as any).totalPages;
-          const apiTotalDocs = (res as any).totalDocs ?? materials.length;
-          const calculatedTotal = Math.ceil(apiTotalDocs / this.pageSize) || 1;
-          this.totalPages = apiTotalPages && apiTotalPages > 0
-            ? apiTotalPages
-            : calculatedTotal;
-
-          // En caso de que la API devuelva todos los elementos sin paginar,
-          // mostramos sólo los correspondientes a la página actual para que el
-          // usuario pueda paginar correctamente.
-          const start = (this.currentPage - 1) * this.pageSize;
-          const end = start + this.pageSize;
-          this.materiales = materials.slice(start, end);
+          this.materiales = Array.isArray(docs) ? docs : [];
         },
         error: err => {
           console.error('Failed to load materials', err);
@@ -63,19 +43,9 @@ export class ListadoMaterialesComponent implements OnInit {
     );
   }
 
-  get pages(): number[] {
-    return Array.from({ length: this.totalPages }, (_, i) => i + 1);
-  }
 
-
-  goToPage(page: number): void {
-    if (page >= 1 && page <= this.totalPages) {
-      this.currentPage = page;
-      this.loadMaterials();
-    }
-  }
 
   onFilterChange(): void {
-    // Filtering is done client-side on the current page only
+    // Filtering is done client-side
   }
 }


### PR DESCRIPTION
## Summary
- simplify *ListadoMateriales* table by removing pagination controls
- load entire materials list without slicing and update client filter comment
- drop pagination styles
- update component tests

## Testing
- `npx ng test --watch=false` *(fails: ng could not be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_684bbdad64fc832da2ab29aeaff73029