### PR TITLE
Fix materials list limit

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.spec.ts
+++ b/src/app/listado-materiales/listado-materiales.component.spec.ts
@@ -31,7 +31,7 @@ describe('ListadoMaterialesComponent', () => {
   it('should load materials with valid response', () => {
     (component as any).loadMaterials();
 
-    const req = httpMock.expectOne(`${environment.apiUrl}/materials`);
+    const req = httpMock.expectOne(`${environment.apiUrl}/materials?limit=1000`);
     expect(req.request.method).toBe('GET');
 
     const materials = [{ id: 1, name: 'Mat1', description: 'Desc1' }];
@@ -42,7 +42,7 @@ describe('ListadoMaterialesComponent', () => {
 
   it('should handle mismatched fields', () => {
     (component as any).loadMaterials();
-    const req = httpMock.expectOne(`${environment.apiUrl}/materials`);
+    const req = httpMock.expectOne(`${environment.apiUrl}/materials?limit=1000`);
     expect(req.request.method).toBe('GET');
 
     req.flush({ items: [] });
@@ -52,7 +52,7 @@ describe('ListadoMaterialesComponent', () => {
 
   it('should keep defaults on http error', () => {
     (component as any).loadMaterials();
-    const req = httpMock.expectOne(`${environment.apiUrl}/materials`);
+    const req = httpMock.expectOne(`${environment.apiUrl}/materials?limit=1000`);
     expect(req.request.method).toBe('GET');
 
     try {

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -22,7 +22,8 @@ export class ListadoMaterialesComponent implements OnInit {
   private loadMaterials(): void {
     this.errorMessage = '';
     this.materialService
-      .getMaterials()
+      // Request a large limit so we fetch all materials in one call
+      .getMaterials(undefined, 1000)
       .subscribe({
         next: res => {
           const docs: any = (res as any).docs ?? (res as any).items ?? res;


### PR DESCRIPTION
## Summary
- request a higher limit to fetch all materials
- update tests to match new request URL

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc033aa7c832d9a4769826d5abe95