### PR TITLE
Implement bootstrap pagination in material list

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -24,3 +24,16 @@
     </tr>
   </tbody>
 </table>
+<nav *ngIf="totalPages > 1" aria-label="Materials pagination" class="mt-3">
+  <ul class="pagination justify-content-center">
+    <li class="page-item" [class.disabled]="currentPage === 1">
+      <a class="page-link" href="#" (click)="goToPage(currentPage - 1); $event.preventDefault()">Anterior</a>
+    </li>
+    <li class="page-item" *ngFor="let p of pages" [class.active]="p === currentPage">
+      <a class="page-link" href="#" (click)="goToPage(p); $event.preventDefault()">{{ p }}</a>
+    </li>
+    <li class="page-item" [class.disabled]="currentPage === totalPages">
+      <a class="page-link" href="#" (click)="goToPage(currentPage + 1); $event.preventDefault()">Siguiente</a>
+    </li>
+  </ul>
+</nav>

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -12,6 +12,9 @@ export class ListadoMaterialesComponent implements OnInit {
   filterNombre = '';
   filterDescripcion = '';
   errorMessage = '';
+  currentPage = 1;
+  pageSize = 10;
+  totalPages = 0;
 
   constructor(private materialService: MaterialService) {}
 
@@ -22,12 +25,13 @@ export class ListadoMaterialesComponent implements OnInit {
   private loadMaterials(): void {
     this.errorMessage = '';
     this.materialService
-      // Request a large limit so we fetch all materials in one call
-      .getMaterials(undefined, 1000)
+      .getMaterials(this.currentPage, this.pageSize)
       .subscribe({
         next: res => {
           const docs: any = (res as any).docs ?? (res as any).items ?? res;
           this.materiales = Array.isArray(docs) ? docs : [];
+          const total = (res as any).totalPages ?? 0;
+          this.totalPages = Number.isFinite(total) ? total : 0;
         },
         error: err => {
           console.error('Failed to load materials', err);
@@ -48,5 +52,17 @@ export class ListadoMaterialesComponent implements OnInit {
 
   onFilterChange(): void {
     // Filtering is done client-side
+  }
+
+  get pages(): number[] {
+    return Array.from({ length: this.totalPages }, (_, i) => i + 1);
+  }
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages || page === this.currentPage) {
+      return;
+    }
+    this.currentPage = page;
+    this.loadMaterials();
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- enable bootstrap in `index.html`
- paginate materials table using MaterialService
- add page navigation controls under the table

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc16e36ac832dbe42107c832620d1