### PR TITLE
Fix pagination when API lacks totalPages field

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.spec.ts
+++ b/src/app/listado-materiales/listado-materiales.component.spec.ts
@@ -31,7 +31,7 @@ describe('ListadoMaterialesComponent', () => {
   it('should load materials with valid response', () => {
     (component as any).loadMaterials();
 
-    const req = httpMock.expectOne(`${environment.apiUrl}/materials?limit=1000`);
+    const req = httpMock.expectOne(`${environment.apiUrl}/materials?page=1&limit=10`);
     expect(req.request.method).toBe('GET');
 
     const materials = [{ id: 1, name: 'Mat1', description: 'Desc1' }];
@@ -42,7 +42,7 @@ describe('ListadoMaterialesComponent', () => {
 
   it('should handle mismatched fields', () => {
     (component as any).loadMaterials();
-    const req = httpMock.expectOne(`${environment.apiUrl}/materials?limit=1000`);
+    const req = httpMock.expectOne(`${environment.apiUrl}/materials?page=1&limit=10`);
     expect(req.request.method).toBe('GET');
 
     req.flush({ items: [] });
@@ -52,7 +52,7 @@ describe('ListadoMaterialesComponent', () => {
 
   it('should keep defaults on http error', () => {
     (component as any).loadMaterials();
-    const req = httpMock.expectOne(`${environment.apiUrl}/materials?limit=1000`);
+    const req = httpMock.expectOne(`${environment.apiUrl}/materials?page=1&limit=10`);
     expect(req.request.method).toBe('GET');
 
     try {

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -30,8 +30,14 @@ export class ListadoMaterialesComponent implements OnInit {
         next: res => {
           const docs: any = (res as any).docs ?? (res as any).items ?? res;
           this.materiales = Array.isArray(docs) ? docs : [];
-          const total = (res as any).totalPages ?? 0;
-          this.totalPages = Number.isFinite(total) ? total : 0;
+          let pages: any = (res as any).totalPages;
+          if (!Number.isFinite(pages)) {
+            const totalDocs = (res as any).totalDocs;
+            if (Number.isFinite(totalDocs) && this.pageSize > 0) {
+              pages = Math.ceil(totalDocs / this.pageSize);
+            }
+          }
+          this.totalPages = Number.isFinite(pages) ? pages : 0;
         },
         error: err => {
           console.error('Failed to load materials', err);


### PR DESCRIPTION
## Summary
- compute page count from `totalDocs` when `totalPages` isn't provided
- update pagination tests to expect query params

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc2ad22f0832da9ae5a7c3b2a4b12