### PR TITLE
Add search input for materials

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.css
+++ b/src/app/listado-materiales/listado-materiales.component.css
@@ -14,4 +14,24 @@ th {
   background-color: #444654;
 }
 
+.search-container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.search-container .material-icons {
+  margin-right: 0.5rem;
+  color: #fff;
+}
+
+.search-container input {
+  padding: 0.75rem;
+  border-radius: 4px;
+  border: 1px solid #565869;
+  background-color: #343541;
+  color: #fff;
+  flex: 1;
+}
+
 

--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -1,5 +1,14 @@
 <h2>Listado de materiales</h2>
 <div class="error" *ngIf="errorMessage">{{ errorMessage }}</div>
+<div class="search-container">
+  <span class="material-icons">search</span>
+  <input
+    type="text"
+    placeholder="Buscar materiales"
+    [(ngModel)]="searchText"
+    (input)="onSearchChange()"
+  />
+</div>
 <table *ngIf="materiales?.length">
   <thead>
     <tr>

--- a/src/app/listado-materiales/listado-materiales.component.spec.ts
+++ b/src/app/listado-materiales/listado-materiales.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { ListadoMaterialesComponent } from './listado-materiales.component';
 import { MaterialService } from '../services/material.service';
 import { CookieService } from '../services/cookie.service';
@@ -14,7 +15,7 @@ describe('ListadoMaterialesComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ListadoMaterialesComponent],
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, FormsModule],
       providers: [MaterialService, CookieService],
       schemas: [NO_ERRORS_SCHEMA]
     });

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -15,6 +15,7 @@ export class ListadoMaterialesComponent implements OnInit {
   currentPage = 1;
   pageSize = 10;
   totalPages = 0;
+  searchText = '';
 
   constructor(private materialService: MaterialService) {}
 
@@ -25,7 +26,7 @@ export class ListadoMaterialesComponent implements OnInit {
   private loadMaterials(): void {
     this.errorMessage = '';
     this.materialService
-      .getMaterials(this.currentPage, this.pageSize)
+      .getMaterials(this.currentPage, this.pageSize, this.searchText)
       .subscribe({
         next: res => {
           const docs: any = (res as any).docs ?? (res as any).items ?? res;
@@ -58,6 +59,11 @@ export class ListadoMaterialesComponent implements OnInit {
 
   onFilterChange(): void {
     // Filtering is done client-side
+  }
+
+  onSearchChange(): void {
+    this.currentPage = 1;
+    this.loadMaterials();
   }
 
   get pages(): number[] {

--- a/src/app/services/material.service.ts
+++ b/src/app/services/material.service.ts
@@ -38,7 +38,7 @@ export class MaterialService {
       : { withCredentials: true };
   }
 
-  getMaterials(page?: number, limit?: number): Observable<PaginatedMaterials> {
+  getMaterials(page?: number, limit?: number, search?: string): Observable<PaginatedMaterials> {
     let url = `${environment.apiUrl}/materials`;
     const params: string[] = [];
     if (page !== undefined) {
@@ -46,6 +46,9 @@ export class MaterialService {
     }
     if (limit !== undefined) {
       params.push(`limit=${limit}`);
+    }
+    if (search !== undefined && search !== '') {
+      params.push(`search=${encodeURIComponent(search)}`);
     }
     if (params.length) {
       url += `?${params.join('&')}`;


### PR DESCRIPTION
## Summary
- allow `MaterialService` to accept a search term
- add search bar with icon to listado-materiales component
- style the search bar similar to login fields
- wire up search logic in the component
- update unit test setup

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc8ba3e6c832db0aded84f9205b2e