### PR TITLE
Add breadcrumb to Listado de materiales

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.css
+++ b/src/app/listado-materiales/listado-materiales.component.css
@@ -63,4 +63,10 @@ th {
   border-color: #565869;
 }
 
+.breadcrumb {
+  font-size: 0.85rem;
+  color: #888;
+  margin-bottom: 0.5rem;
+}
+
 

--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -1,3 +1,4 @@
+<nav class="breadcrumb">Inicio / Listado de materiales</nav>
 <h2>Listado de materiales</h2>
 <div class="error" *ngIf="errorMessage">{{ errorMessage }}</div>
 <div class="search-container">


### PR DESCRIPTION
## Summary
- add a breadcrumb on Listado de materiales screen
- style breadcrumb like in Settings

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bcabe6088832d8607156584a1d219