### PR TITLE
Improve login error handling

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostListener, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpErrorResponse } from '@angular/common/http';
 import { CookieService } from './services/cookie.service';
 import { environment } from '../environments/environment';
 
@@ -108,8 +108,10 @@ export class AppComponent implements OnInit {
           this.user = { name: res.user.username, company: res.ownerCompany.name };
           this.resetInactivityTimer();
         },
-        error: () => {
-          this.error = 'Los datos son incorrectos';
+        error: (err: HttpErrorResponse) => {
+          this.error = err.status === 0
+            ? 'Ocurrió un error, contacte al administrador'
+            : 'Los datos son incorrectos';
         }
       });
   }


### PR DESCRIPTION
## Summary
- make login error message clearer when API is unreachable

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c41a5d1f8832d9ad5758a019dbb73