### PR TITLE
Add spacing and tooltip to materials list

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.css
+++ b/src/app/listado-materiales/listado-materiales.component.css
@@ -22,6 +22,7 @@ th {
 .search-container {
   display: flex;
   align-items: center;
+  margin-top: 2rem;
   margin-bottom: 1rem;
 }
 

--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -11,7 +11,7 @@
   />
 </div>
 <div class="button-bar">
-  <button type="button" class="add-material-btn">
+  <button type="button" class="add-material-btn" title="Agregar Material">
     <span class="material-icons" aria-hidden="true">add</span>
   </button>
 </div>


### PR DESCRIPTION
## Summary
- place search bar further from the heading
- show tooltip on add-material button

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c44b69f20832d9a95cdb0b0867413