### PR TITLE
Add form validation and loader for materials

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.css
+++ b/src/app/listado-materiales/listado-materiales.component.css
@@ -145,6 +145,34 @@ th {
 .add-modal .form-actions {
   display: flex;
   justify-content: center;
+  position: relative;
+}
+
+.loader-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #10a37f;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }
 
 

--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -62,14 +62,14 @@
   <div class="add-modal" (click)="$event.stopPropagation()">
     <span class="close-icon material-icons" (click)="closeAddModal()">close</span>
     <h3>Agregar material</h3>
-    <form (ngSubmit)="saveMaterial()">
+    <form (ngSubmit)="saveMaterial()" #materialForm="ngForm">
       <div class="form-group">
         <label for="mat-name">Nombre</label>
         <input id="mat-name" type="text" [(ngModel)]="newMaterial.name" name="name" required />
       </div>
       <div class="form-group">
         <label for="mat-desc">Descripción</label>
-        <textarea id="mat-desc" [(ngModel)]="newMaterial.description" name="description"></textarea>
+        <textarea id="mat-desc" [(ngModel)]="newMaterial.description" name="description" required></textarea>
       </div>
       <div class="form-group">
         <label for="mat-thick">Espesor (mm)</label>
@@ -85,11 +85,14 @@
       </div>
       <div class="form-group">
         <label for="mat-price">Precio</label>
-        <input id="mat-price" type="number" [(ngModel)]="newMaterial.price" name="price" />
+        <input id="mat-price" type="number" [(ngModel)]="newMaterial.price" name="price" required />
       </div>
       <div class="error" *ngIf="saveError">{{ saveError }}</div>
       <div class="form-actions">
-        <button type="submit">Guardar</button>
+        <button type="submit" [disabled]="isSaving || !materialForm.form.valid">Guardar</button>
+        <div class="loader-overlay" *ngIf="isSaving">
+          <div class="spinner"></div>
+        </div>
       </div>
     </form>
   </div>

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -26,6 +26,7 @@ export class ListadoMaterialesComponent implements OnInit {
     price: undefined
   };
   saveError = '';
+  isSaving = false;
 
   constructor(private materialService: MaterialService) {}
 
@@ -64,17 +65,24 @@ export class ListadoMaterialesComponent implements OnInit {
   closeAddModal(): void {
     this.showAddModal = false;
     this.saveError = '';
+    this.isSaving = false;
   }
 
   saveMaterial(): void {
+    if (this.isSaving) {
+      return;
+    }
     this.saveError = '';
+    this.isSaving = true;
     this.materialService.addMaterial(this.newMaterial).subscribe({
       next: () => {
+        this.isSaving = false;
         this.resetNewMaterial();
         this.closeAddModal();
         this.loadMaterials();
       },
       error: err => {
+        this.isSaving = false;
         console.error('Failed to add material', err);
         this.saveError = 'Error al guardar el material';
       }


### PR DESCRIPTION
## Summary
- require description and price when adding a material
- disable Save button until form valid and show loader while saving
- style loader overlay and spinner

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c6e2062dc832dabb282553fd07132