### PR TITLE
Fix material form validation

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -62,7 +62,7 @@
   <div class="add-modal" (click)="$event.stopPropagation()">
     <span class="close-icon material-icons" (click)="closeAddModal()">close</span>
     <h3>Agregar material</h3>
-    <form (ngSubmit)="saveMaterial()" #materialForm="ngForm">
+    <form (ngSubmit)="saveMaterial(materialForm)" #materialForm="ngForm">
       <div class="form-group">
         <label for="mat-name">Nombre</label>
         <input id="mat-name" type="text" [(ngModel)]="newMaterial.name" name="name" required />

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { NgForm } from '@angular/forms';
 import { MaterialService, Material, NewMaterial } from '../services/material.service';
 
 @Component({
@@ -66,10 +67,15 @@ export class ListadoMaterialesComponent implements OnInit {
     this.showAddModal = false;
     this.saveError = '';
     this.isSaving = false;
+    this.resetNewMaterial();
   }
 
-  saveMaterial(): void {
+  saveMaterial(form: NgForm): void {
     if (this.isSaving) {
+      return;
+    }
+    if (form.invalid) {
+      form.form.markAllAsTouched();
       return;
     }
     this.saveError = '';


### PR DESCRIPTION
## Summary
- check form validity before calling service when adding material
- reset form values when closing modal

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6f414034832d8ccb5a42cfc468cc