### PR TITLE
Fix material form validation messages

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.css
+++ b/src/app/listado-materiales/listado-materiales.component.css
@@ -142,6 +142,11 @@ th {
   width: 100%;
 }
 
+.add-modal input.ng-invalid.ng-touched,
+.add-modal textarea.ng-invalid.ng-touched {
+  border-color: #ff6b6b;
+}
+
 .add-modal .form-actions {
   display: flex;
   justify-content: center;

--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -65,11 +65,30 @@
     <form (ngSubmit)="saveMaterial(materialForm)" #materialForm="ngForm">
       <div class="form-group">
         <label for="mat-name">Nombre</label>
-        <input id="mat-name" type="text" [(ngModel)]="newMaterial.name" name="name" required />
+        <input
+          id="mat-name"
+          type="text"
+          [(ngModel)]="newMaterial.name"
+          name="name"
+          required
+          #nameRef="ngModel"
+        />
+        <div class="error" *ngIf="nameRef.touched && nameRef.hasError('required')">
+          El nombre es requerido
+        </div>
       </div>
       <div class="form-group">
         <label for="mat-desc">Descripción</label>
-        <textarea id="mat-desc" [(ngModel)]="newMaterial.description" name="description" required></textarea>
+        <textarea
+          id="mat-desc"
+          [(ngModel)]="newMaterial.description"
+          name="description"
+          required
+          #descRef="ngModel"
+        ></textarea>
+        <div class="error" *ngIf="descRef.touched && descRef.hasError('required')">
+          La descripción es requerida
+        </div>
       </div>
       <div class="form-group">
         <label for="mat-thick">Espesor (mm)</label>
@@ -85,7 +104,17 @@
       </div>
       <div class="form-group">
         <label for="mat-price">Precio</label>
-        <input id="mat-price" type="number" [(ngModel)]="newMaterial.price" name="price" required />
+        <input
+          id="mat-price"
+          type="number"
+          [(ngModel)]="newMaterial.price"
+          name="price"
+          required
+          #priceRef="ngModel"
+        />
+        <div class="error" *ngIf="priceRef.touched && priceRef.hasError('required')">
+          El precio es requerido
+        </div>
       </div>
       <div class="error" *ngIf="saveError">{{ saveError }}</div>
       <div class="form-actions">


### PR DESCRIPTION
## Summary
- show validation messages for required fields in the add material form
- highlight invalid inputs in the modal

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c794b49bc832d994ee7f10b9aa983