### PR TITLE
Add edit button column to materials table

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.css
+++ b/src/app/listado-materiales/listado-materiales.component.css
@@ -91,6 +91,25 @@ th {
   font-size: 1.2rem;
 }
 
+.edit-btn {
+  background-color: #10a37f;
+  border: none;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.edit-btn:hover {
+  background-color: #0e8a6e;
+}
+
+.edit-btn .material-icons {
+  font-size: 1.2rem;
+}
+
 .modal-overlay {
   position: fixed;
   top: 0;

--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -30,6 +30,7 @@
       <th>Ancho (m)</th>
       <th>Largo (m)</th>
       <th>Precio</th>
+      <th>Acciones</th>
     </tr>
   </thead>
   <tbody>
@@ -41,6 +42,16 @@
       <td>{{ item.width_m }}</td>
       <td>{{ item.length_m }}</td>
       <td>{{ item.price }}</td>
+      <td>
+        <button
+          type="button"
+          class="edit-btn"
+          title="Editar Material"
+          (click)="editMaterial(item)"
+        >
+          <span class="material-icons" aria-hidden="true">edit</span>
+        </button>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -136,4 +136,9 @@ export class ListadoMaterialesComponent implements OnInit {
     this.currentPage = page;
     this.loadMaterials();
   }
+
+  editMaterial(material: Material): void {
+    // Placeholder for edit logic
+    console.log('Edit material', material);
+  }
 }


### PR DESCRIPTION
## Summary
- add Actions column in materials table with new edit button
- style the edit button to match the theme
- stub edit function in component

## Testing
- `npm test --silent --unsafe-perm=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8a671b60832da3c6e307e2eb023e