### PR TITLE
Add edit modal

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -137,3 +137,67 @@
     </form>
   </div>
 </div>
+<div class="modal-overlay" *ngIf="showEditModal" (click)="closeEditModal()">
+  <div class="add-modal" (click)="$event.stopPropagation()">
+    <span class="close-icon material-icons" (click)="closeEditModal()">close</span>
+    <h3>Editar material</h3>
+    <form (ngSubmit)="updateMaterial(editForm)" #editForm="ngForm">
+      <div class="form-group">
+        <label for="edit-name">Nombre</label>
+        <input
+          id="edit-name"
+          type="text"
+          [(ngModel)]="editMaterialData.name"
+          name="name"
+          required
+          #editNameRef="ngModel"
+        />
+        <div class="error" *ngIf="editNameRef.touched && editNameRef.hasError('required')">
+          El nombre es requerido
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="edit-desc">Descripción</label>
+        <textarea
+          id="edit-desc"
+          [(ngModel)]="editMaterialData.description"
+          name="description"
+          required
+          #editDescRef="ngModel"
+        ></textarea>
+        <div class="error" *ngIf="editDescRef.touched && editDescRef.hasError('required')">
+          La descripción es requerida
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="edit-thick">Espesor (mm)</label>
+        <input id="edit-thick" type="number" [(ngModel)]="editMaterialData.thickness_mm" name="thickness_mm" />
+      </div>
+      <div class="form-group">
+        <label for="edit-width">Ancho (m)</label>
+        <input id="edit-width" type="number" [(ngModel)]="editMaterialData.width_m" name="width_m" />
+      </div>
+      <div class="form-group">
+        <label for="edit-length">Largo (m)</label>
+        <input id="edit-length" type="number" [(ngModel)]="editMaterialData.length_m" name="length_m" />
+      </div>
+      <div class="form-group">
+        <label for="edit-price">Precio</label>
+        <input
+          id="edit-price"
+          type="number"
+          [(ngModel)]="editMaterialData.price"
+          name="price"
+          required
+          #editPriceRef="ngModel"
+        />
+        <div class="error" *ngIf="editPriceRef.touched && editPriceRef.hasError('required')">
+          El precio es requerido
+        </div>
+      </div>
+      <div class="form-actions">
+        <button type="submit" [disabled]="!editForm.form.valid">Guardar</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -18,6 +18,15 @@ export class ListadoMaterialesComponent implements OnInit {
   totalPages = 0;
   searchText = '';
   showAddModal = false;
+  showEditModal = false;
+  editMaterialData: NewMaterial = {
+    name: '',
+    description: '',
+    thickness_mm: undefined,
+    width_m: undefined,
+    length_m: undefined,
+    price: undefined
+  };
   newMaterial: NewMaterial = {
     name: '',
     description: '',
@@ -68,6 +77,27 @@ export class ListadoMaterialesComponent implements OnInit {
     this.saveError = '';
     this.isSaving = false;
     this.resetNewMaterial();
+  }
+
+  openEditModal(material: Material): void {
+    this.editMaterialData = {
+      name: material.name,
+      description: material.description,
+      thickness_mm: material.thickness_mm,
+      width_m: material.width_m,
+      length_m: material.length_m,
+      price: material.price
+    };
+    this.showEditModal = true;
+  }
+
+  closeEditModal(): void {
+    this.showEditModal = false;
+  }
+
+  updateMaterial(form: NgForm): void {
+    // Placeholder for update logic
+    console.log('Update material', this.editMaterialData);
   }
 
   saveMaterial(form: NgForm): void {
@@ -138,7 +168,6 @@ export class ListadoMaterialesComponent implements OnInit {
   }
 
   editMaterial(material: Material): void {
-    // Placeholder for edit logic
-    console.log('Edit material', material);
+    this.openEditModal(material);
   }
 }


### PR DESCRIPTION
## Summary
- trigger edit modal that reuses the material form
- show the modal with pre-populated data

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_684c8deb0128832dbea99b26a78c6dd6