### PR TITLE
Ensure edit material modal uses same validations

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -195,8 +195,12 @@
           El precio es requerido
         </div>
       </div>
+      <div class="error" *ngIf="updateError">{{ updateError }}</div>
       <div class="form-actions">
-        <button type="submit" [disabled]="!editForm.form.valid">Guardar</button>
+        <button type="submit" [disabled]="isUpdating || !editForm.form.valid">Guardar</button>
+        <div class="loader-overlay" *ngIf="isUpdating">
+          <div class="spinner"></div>
+        </div>
       </div>
     </form>
   </div>

--- a/src/app/listado-materiales/listado-materiales.component.spec.ts
+++ b/src/app/listado-materiales/listado-materiales.component.spec.ts
@@ -62,4 +62,29 @@ describe('ListadoMaterialesComponent', () => {
 
     expect(component.materiales).toEqual([]);
   });
+
+  it('should send PUT request when updating material', () => {
+    component.editMaterialData = {
+      name: 'Mat1',
+      description: 'Desc',
+      thickness_mm: 1,
+      width_m: 2,
+      length_m: 3,
+      price: 10
+    };
+    (component as any).editingMaterialId = 5;
+    const fakeForm: any = { invalid: false, form: { markAllAsTouched: () => {} } };
+    component.updateMaterial(fakeForm as any);
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/materials/5`);
+    expect(req.request.method).toBe('PUT');
+    req.flush({});
+  });
+
+  it('should not send request if update form is invalid', () => {
+    const fakeForm: any = { invalid: true, form: { markAllAsTouched: () => {} } };
+    component.updateMaterial(fakeForm as any);
+    const reqs = httpMock.match(() => true);
+    expect(reqs.length).toBe(0);
+  });
 });

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -19,6 +19,7 @@ export class ListadoMaterialesComponent implements OnInit {
   searchText = '';
   showAddModal = false;
   showEditModal = false;
+  editingMaterialId: number | null = null;
   editMaterialData: NewMaterial = {
     name: '',
     description: '',
@@ -36,7 +37,9 @@ export class ListadoMaterialesComponent implements OnInit {
     price: undefined
   };
   saveError = '';
+  updateError = '';
   isSaving = false;
+  isUpdating = false;
 
   constructor(private materialService: MaterialService) {}
 
@@ -80,6 +83,7 @@ export class ListadoMaterialesComponent implements OnInit {
   }
 
   openEditModal(material: Material): void {
+    this.editingMaterialId = material.id;
     this.editMaterialData = {
       name: material.name,
       description: material.description,
@@ -88,16 +92,45 @@ export class ListadoMaterialesComponent implements OnInit {
       length_m: material.length_m,
       price: material.price
     };
+    this.updateError = '';
+    this.isUpdating = false;
     this.showEditModal = true;
   }
 
   closeEditModal(): void {
     this.showEditModal = false;
+    this.editingMaterialId = null;
+    this.updateError = '';
+    this.isUpdating = false;
   }
 
   updateMaterial(form: NgForm): void {
-    // Placeholder for update logic
-    console.log('Update material', this.editMaterialData);
+    if (this.isUpdating) {
+      return;
+    }
+    if (form.invalid) {
+      form.form.markAllAsTouched();
+      return;
+    }
+    if (this.editingMaterialId === null) {
+      return;
+    }
+    this.updateError = '';
+    this.isUpdating = true;
+    this.materialService
+      .updateMaterial(this.editingMaterialId, this.editMaterialData)
+      .subscribe({
+        next: () => {
+          this.isUpdating = false;
+          this.closeEditModal();
+          this.loadMaterials();
+        },
+        error: err => {
+          this.isUpdating = false;
+          console.error('Failed to update material', err);
+          this.updateError = 'Error al actualizar el material';
+        }
+      });
   }
 
   saveMaterial(form: NgForm): void {

--- a/src/app/services/material.service.ts
+++ b/src/app/services/material.service.ts
@@ -65,4 +65,12 @@ export class MaterialService {
       this.httpOptions()
     );
   }
+
+  updateMaterial(id: number, material: NewMaterial): Observable<Material> {
+    return this.http.put<Material>(
+      `${environment.apiUrl}/materials/${id}`,
+      material,
+      this.httpOptions()
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- add `updateMaterial` API call in MaterialService
- improve `updateMaterial` method in ListadoMaterialesComponent with validation and loader
- reset edit modal state when opening/closing
- show update error messages and spinner in the edit modal
- add unit tests for update flow

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c90499084832d93b389e80aac9729