### PR TITLE
Fix modal closing when selecting text

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -69,8 +69,8 @@
   </ul>
 </nav>
 
-<div class="modal-overlay" *ngIf="showAddModal" (click)="closeAddModal()">
-  <div class="add-modal" (click)="$event.stopPropagation()">
+<div class="modal-overlay" *ngIf="showAddModal" (mousedown)="closeAddModal()">
+  <div class="add-modal" (mousedown)="$event.stopPropagation()" (click)="$event.stopPropagation()">
     <span class="close-icon material-icons" (click)="closeAddModal()">close</span>
     <h3>Agregar material</h3>
     <form (ngSubmit)="saveMaterial(materialForm)" #materialForm="ngForm">
@@ -137,8 +137,8 @@
     </form>
   </div>
 </div>
-<div class="modal-overlay" *ngIf="showEditModal" (click)="closeEditModal()">
-  <div class="add-modal" (click)="$event.stopPropagation()">
+<div class="modal-overlay" *ngIf="showEditModal" (mousedown)="closeEditModal()">
+  <div class="add-modal" (mousedown)="$event.stopPropagation()" (click)="$event.stopPropagation()">
     <span class="close-icon material-icons" (click)="closeEditModal()">close</span>
     <h3>Editar material</h3>
     <form (ngSubmit)="updateMaterial(editForm)" #editForm="ngForm">


### PR DESCRIPTION
## Summary
- stop closing material modals on text selection by using `mousedown` events

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c912dc798832da139b5bacd88a883