### PR TITLE
Display file column with pdf icon

### DIFF
--- a/src/app/cotizaciones/cotizaciones.component.css
+++ b/src/app/cotizaciones/cotizaciones.component.css
@@ -24,3 +24,10 @@ tbody tr:not(:last-child) td {
 th {
   background-color: #444654;
 }
+
+.pdf-icon {
+  margin-right: 0.25rem;
+  vertical-align: middle;
+  color: #e53e3e;
+  font-size: 1.2rem;
+}

--- a/src/app/cotizaciones/cotizaciones.component.html
+++ b/src/app/cotizaciones/cotizaciones.component.html
@@ -9,7 +9,15 @@
   </thead>
   <tbody>
     <tr *ngFor="let item of remisiones">
-      <td *ngFor="let h of headers">{{ item[h] }}</td>
+      <td *ngFor="let h of headers">
+        <ng-container *ngIf="h === 'file'; else defaultCell">
+          <span class="material-icons pdf-icon" aria-hidden="true"
+            >picture_as_pdf</span
+          >
+          {{ item[h] }}
+        </ng-container>
+        <ng-template #defaultCell>{{ item[h] }}</ng-template>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/src/app/cotizaciones/cotizaciones.component.ts
+++ b/src/app/cotizaciones/cotizaciones.component.ts
@@ -35,7 +35,8 @@ export class CotizacionesComponent implements OnInit {
                 const clone: any = { ...item };
                 delete clone.data;
                 if (typeof clone.pdf_path === 'string') {
-                  const parts = clone.pdf_path.split('/');
+                  // Handle both Unix and Windows style paths
+                  const parts = clone.pdf_path.split(/[\\/]/);
                   clone.file = parts[parts.length - 1];
                   delete clone.pdf_path;
                 }


### PR DESCRIPTION
## Summary
- show pdf icon beside file name in quotes table
- support Windows-style file paths
- add styling for pdf icon

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d9fa48b8832dbe935106b469b266