### PR TITLE
Enable PDF preview modal in Cotizaciones table

### DIFF
--- a/src/app/cotizaciones/cotizaciones.component.css
+++ b/src/app/cotizaciones/cotizaciones.component.css
@@ -31,3 +31,54 @@ th {
   color: #e53e3e;
   font-size: 1.2rem;
 }
+
+.file-link {
+  background: none;
+  border: none;
+  color: #4299e1;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.pdf-modal {
+  background-color: #444654;
+  padding: 1rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 800px;
+  height: 90vh;
+  position: relative;
+  color: #e8e8e8;
+  display: flex;
+  flex-direction: column;
+}
+
+.pdf-modal iframe {
+  flex: 1;
+  width: 100%;
+  border: none;
+}
+
+.close-icon {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+  z-index: 10;
+}

--- a/src/app/cotizaciones/cotizaciones.component.html
+++ b/src/app/cotizaciones/cotizaciones.component.html
@@ -11,13 +11,26 @@
     <tr *ngFor="let item of remisiones">
       <td *ngFor="let h of headers">
         <ng-container *ngIf="h === 'file'; else defaultCell">
-          <span class="material-icons pdf-icon" aria-hidden="true"
-            >picture_as_pdf</span
-          >
-          {{ item[h] }}
+          <button class="file-link" (click)="openPdf(item._pdfUrl)">
+            <span class="material-icons pdf-icon" aria-hidden="true"
+              >picture_as_pdf</span
+            >
+            {{ item[h] }}
+          </button>
         </ng-container>
         <ng-template #defaultCell>{{ item[h] }}</ng-template>
       </td>
     </tr>
   </tbody>
 </table>
+
+<div class="modal-overlay" *ngIf="showPdfModal" (mousedown)="closePdfModal()">
+  <div
+    class="pdf-modal"
+    (mousedown)="$event.stopPropagation()"
+    (click)="$event.stopPropagation()"
+  >
+    <span class="close-icon material-icons" (click)="closePdfModal()">close</span>
+    <iframe [src]="selectedPdf" frameborder="0"></iframe>
+  </div>
+</div>

--- a/src/app/cotizaciones/cotizaciones.component.ts
+++ b/src/app/cotizaciones/cotizaciones.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { RemissionService } from '../services/remission.service';
 import { CookieService } from '../services/cookie.service';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-cotizaciones',
@@ -10,10 +11,13 @@ import { CookieService } from '../services/cookie.service';
 export class CotizacionesComponent implements OnInit {
   remisiones: any[] = [];
   errorMessage = '';
+  showPdfModal = false;
+  selectedPdf: SafeResourceUrl | null = null;
 
   constructor(
     private remissionService: RemissionService,
-    private cookieService: CookieService
+    private cookieService: CookieService,
+    private sanitizer: DomSanitizer
   ) {}
 
   ngOnInit(): void {
@@ -38,6 +42,7 @@ export class CotizacionesComponent implements OnInit {
                   // Handle both Unix and Windows style paths
                   const parts = clone.pdf_path.split(/[\\/]/);
                   clone.file = parts[parts.length - 1];
+                  clone._pdfUrl = clone.pdf_path;
                   delete clone.pdf_path;
                 }
                 return clone;
@@ -54,7 +59,19 @@ export class CotizacionesComponent implements OnInit {
     }
   }
 
+  openPdf(url: string): void {
+    this.selectedPdf = this.sanitizer.bypassSecurityTrustResourceUrl(url);
+    this.showPdfModal = true;
+  }
+
+  closePdfModal(): void {
+    this.showPdfModal = false;
+    this.selectedPdf = null;
+  }
+
   get headers(): string[] {
-    return this.remisiones.length ? Object.keys(this.remisiones[0]) : [];
+    return this.remisiones.length
+      ? Object.keys(this.remisiones[0]).filter(h => !h.startsWith('_'))
+      : [];
   }
 }


### PR DESCRIPTION
## Summary
- open PDF in a modal when clicking the *file* column in Cotizaciones
- store the PDF URL per row and sanitize it
- style modal and add button styling

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859db244bfc832d963b000557f4cfde