### PR TITLE
Add PDF viewer for quotes modal

### DIFF
--- a/src/app/cotizaciones/cotizaciones.component.css
+++ b/src/app/cotizaciones/cotizaciones.component.css
@@ -69,7 +69,7 @@ th {
   flex-direction: column;
 }
 
-.pdf-modal iframe {
+.pdf-modal object {
   flex: 1;
   width: 100%;
   border: none;

--- a/src/app/cotizaciones/cotizaciones.component.html
+++ b/src/app/cotizaciones/cotizaciones.component.html
@@ -31,6 +31,11 @@
     (click)="$event.stopPropagation()"
   >
     <span class="close-icon material-icons" (click)="closePdfModal()">close</span>
-    <iframe [src]="selectedPdf" frameborder="0"></iframe>
+    <object [data]="selectedPdf" type="application/pdf">
+      <p>
+        No se pudo visualizar el PDF.
+        <a [href]="selectedPdf" target="_blank">Descargar</a>
+      </p>
+    </object>
   </div>
 </div>

--- a/src/app/cotizaciones/cotizaciones.component.ts
+++ b/src/app/cotizaciones/cotizaciones.component.ts
@@ -49,7 +49,9 @@ export class CotizacionesComponent implements OnInit {
                   const parts = clone.pdf_path.split(/[\\/]/);
                   const fileName = parts[parts.length - 1];
                   clone.file = fileName;
-                  clone._pdfUrl = `remissions/${fileName}`;
+                  // Build the absolute URL to the PDF so the modal viewer can
+                  // request it directly from the API server.
+                  clone._pdfUrl = `${environment.apiUrl}/remissions/${fileName}`;
                   delete clone.pdf_path;
                 }
                 if (clone.client && typeof clone.client === 'object') {


### PR DESCRIPTION
## Summary
- build absolute PDF URL so path is correct
- show PDFs in quotes modal using `<object>` viewer
- style modal viewer

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859de3c80fc832d824d733107966fc9