### PR TITLE
Modify PDF viewer for 100% width

### DIFF
--- a/src/app/cotizaciones/cotizaciones.component.css
+++ b/src/app/cotizaciones/cotizaciones.component.css
@@ -60,8 +60,8 @@ th {
   background-color: #444654;
   padding: 1rem;
   border-radius: 8px;
-  width: 90%;
-  max-width: 800px;
+  width: 95%;
+  max-width: 1200px;
   height: 90vh;
   position: relative;
   color: #e8e8e8;

--- a/src/app/cotizaciones/cotizaciones.component.ts
+++ b/src/app/cotizaciones/cotizaciones.component.ts
@@ -82,6 +82,8 @@ export class CotizacionesComponent implements OnInit {
       const normalized = url.startsWith('/') ? url : `/${url}`;
       finalUrl = `${environment.apiUrl}${normalized}`;
     }
+    const viewerParams = 'zoom=page-width&pagemode=none';
+    finalUrl += finalUrl.includes('#') ? `&${viewerParams}` : `#${viewerParams}`;
     this.selectedPdf = this.sanitizer.bypassSecurityTrustResourceUrl(finalUrl);
     this.showPdfModal = true;
   }


### PR DESCRIPTION
## Summary
- open PDFs without the navigation pane so only the page is shown
- widen the modal so a page fits at full width

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6859e10330cc832db3fb048ad2b56f93