### PR TITLE
Fix PDF viewer default zoom

### DIFF
--- a/src/app/cotizaciones/cotizaciones.component.ts
+++ b/src/app/cotizaciones/cotizaciones.component.ts
@@ -82,7 +82,8 @@ export class CotizacionesComponent implements OnInit {
       const normalized = url.startsWith('/') ? url : `/${url}`;
       finalUrl = `${environment.apiUrl}${normalized}`;
     }
-    const viewerParams = 'zoom=page-width&pagemode=none';
+    // Open the PDF at 100% zoom instead of fitting the page width
+    const viewerParams = 'zoom=100&pagemode=none';
     finalUrl += finalUrl.includes('#') ? `&${viewerParams}` : `#${viewerParams}`;
     this.selectedPdf = this.sanitizer.bypassSecurityTrustResourceUrl(finalUrl);
     this.showPdfModal = true;


### PR DESCRIPTION
## Summary
- show PDFs in the modal at 100% zoom instead of fitting to page width

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e1e7c438832da3984c8de48f81eb