### PR TITLE
Add pagination for cotizaciones

### DIFF
--- a/src/app/cotizaciones/cotizaciones.component.css
+++ b/src/app/cotizaciones/cotizaciones.component.css
@@ -82,3 +82,48 @@ th {
   cursor: pointer;
   z-index: 10;
 }
+
+.search-container {
+  display: flex;
+  align-items: center;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.search-container .material-icons {
+  margin-right: 0.5rem;
+  color: #fff;
+}
+
+.search-container input {
+  padding: 0.75rem;
+  border-radius: 4px;
+  border: 1px solid #565869;
+  background-color: #343541;
+  color: #fff;
+  flex: 1;
+}
+
+/* Pagination styles aligned with the platform colors */
+.pagination .page-link {
+  background-color: #444654;
+  color: #e8e8e8;
+  border: 1px solid #565869;
+}
+
+.pagination .page-link:hover {
+  background-color: #0e8a6e;
+  color: #fff;
+}
+
+.page-item.active .page-link {
+  background-color: #10a37f;
+  border-color: #10a37f;
+  color: #fff;
+}
+
+.page-item.disabled .page-link {
+  background-color: #343541;
+  color: #777;
+  border-color: #565869;
+}

--- a/src/app/cotizaciones/cotizaciones.component.html
+++ b/src/app/cotizaciones/cotizaciones.component.html
@@ -1,6 +1,15 @@
 <nav class="breadcrumb">Inicio / Cotizaciones</nav>
 <h2>Cotizaciones</h2>
 <div class="error" *ngIf="errorMessage">{{ errorMessage }}</div>
+<div class="search-container">
+  <span class="material-icons">search</span>
+  <input
+    type="text"
+    placeholder="Buscar cotizaciones"
+    [(ngModel)]="searchText"
+    (input)="onSearchChange()"
+  />
+</div>
 <table *ngIf="remisiones?.length">
   <thead>
     <tr>
@@ -23,6 +32,19 @@
     </tr>
   </tbody>
 </table>
+<nav *ngIf="totalPages > 1" aria-label="Remissions pagination" class="mt-3">
+  <ul class="pagination justify-content-center">
+    <li class="page-item" [class.disabled]="currentPage === 1">
+      <a class="page-link" href="#" (click)="goToPage(currentPage - 1); $event.preventDefault()">Anterior</a>
+    </li>
+    <li class="page-item" *ngFor="let p of pages" [class.active]="p === currentPage">
+      <a class="page-link" href="#" (click)="goToPage(p); $event.preventDefault()">{{ p }}</a>
+    </li>
+    <li class="page-item" [class.disabled]="currentPage === totalPages">
+      <a class="page-link" href="#" (click)="goToPage(currentPage + 1); $event.preventDefault()">Siguiente</a>
+    </li>
+  </ul>
+</nav>
 
 <div class="modal-overlay" *ngIf="showPdfModal" (mousedown)="closePdfModal()">
   <div

--- a/src/app/services/remission.service.ts
+++ b/src/app/services/remission.service.ts
@@ -7,6 +7,14 @@ import { environment } from '../../environments/environment';
 @Injectable({
   providedIn: 'root'
 })
+export interface PaginatedRemissions {
+  docs: any[];
+  totalDocs: number;
+  limit: number;
+  page: number;
+  totalPages: number;
+}
+
 export class RemissionService {
   constructor(private http: HttpClient, private cookieService: CookieService) {}
 
@@ -17,10 +25,26 @@ export class RemissionService {
       : { withCredentials: true };
   }
 
-  getByOwner(ownerId: number): Observable<any[]> {
-    return this.http.get<any[]>(
-      `${environment.apiUrl}/remissions/by-owner/${ownerId}`,
-      this.httpOptions()
-    );
+  getByOwner(
+    ownerId: number,
+    page?: number,
+    limit?: number,
+    search?: string
+  ): Observable<PaginatedRemissions> {
+    let url = `${environment.apiUrl}/remissions/by-owner/${ownerId}`;
+    const params: string[] = [];
+    if (page !== undefined) {
+      params.push(`page=${page}`);
+    }
+    if (limit !== undefined) {
+      params.push(`limit=${limit}`);
+    }
+    if (search !== undefined && search !== '') {
+      params.push(`search=${encodeURIComponent(search)}`);
+    }
+    if (params.length) {
+      url += `?${params.join('&')}`;
+    }
+    return this.http.get<PaginatedRemissions>(url, this.httpOptions());
   }
 }


### PR DESCRIPTION
## Summary
- extend `RemissionService` with pagination parameters
- enable pagination and search in `cotizaciones` component
- display controls and styles for cotizaciones pagination

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e356e678832d93dce7965edd8062