### PR TITLE
Fix RemissionService decorator placement

### DIFF
--- a/src/app/services/remission.service.ts
+++ b/src/app/services/remission.service.ts
@@ -4,9 +4,6 @@ import { Observable } from 'rxjs';
 import { CookieService } from './cookie.service';
 import { environment } from '../../environments/environment';
 
-@Injectable({
-  providedIn: 'root'
-})
 export interface PaginatedRemissions {
   docs: any[];
   totalDocs: number;
@@ -15,6 +12,9 @@ export interface PaginatedRemissions {
   totalPages: number;
 }
 
+@Injectable({
+  providedIn: 'root'
+})
 export class RemissionService {
   constructor(private http: HttpClient, private cookieService: CookieService) {}
 


### PR DESCRIPTION
## Summary
- fix the placement of `@Injectable` in `RemissionService`

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e4b3a394832d9b7146af3dfd1a65