### PR TITLE
Fix materials route path

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -14,7 +14,7 @@ const routes: Routes = [
   { path: 'ventas', component: VentasComponent },
   { path: 'inventario/productos', component: ProductosComponent },
   { path: 'inventario/bodegas', component: BodegasComponent },
-  { path: 'listado_materiales', component: ListadoMaterialesComponent },
+  { path: 'materiales', component: ListadoMaterialesComponent },
   { path: 'cotizaciones', component: CotizacionesComponent },
   { path: 'settings', component: SettingsComponent }
 ];

--- a/src/app/sidebar/sidebar.component.spec.ts
+++ b/src/app/sidebar/sidebar.component.spec.ts
@@ -38,7 +38,7 @@ describe('SidebarComponent', () => {
             children: [
               { id: 5, name: 'Productos', path: 'inventario/productos' },
               { id: 6, name: 'Bodegas', path: 'inventario/bodegas' },
-              { id: 7, name: 'Materiales', path: 'listado_materiales' }
+              { id: 7, name: 'Materiales', path: 'materiales' }
             ]
           }
         ]


### PR DESCRIPTION
## Summary
- update route path for `materiales`
- align sidebar spec with new route

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f66872f0832d8180c4ba93daa4c2