### PR TITLE
Add breadcrumb navigation to Accesorios component

### DIFF
--- a/src/app/accesorios/accesorios.component.css
+++ b/src/app/accesorios/accesorios.component.css
@@ -1,0 +1,6 @@
+nav.breadcrumb,
+.breadcrumb {
+  font-size: 0.85rem;
+  color: #888;
+  margin-bottom: 0.5rem;
+}

--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -1,1 +1,2 @@
+<nav class="breadcrumb">Inicio / Accesorios</nav>
 <h2>Accesorios</h2>


### PR DESCRIPTION
## Summary
- add missing navigation breadcrumb above the Accesorios title
- style breadcrumb like other pages

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859f8ffb2a8832dad4241c69f354d09