### PR TITLE
Add accessory material search

### DIFF
--- a/src/app/accesorios/accesorios.component.css
+++ b/src/app/accesorios/accesorios.component.css
@@ -1,0 +1,74 @@
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+th,
+td {
+  padding: 0.75rem;
+}
+
+tbody tr:not(:last-child) td {
+  border-bottom: 1px solid #565869;
+}
+
+th {
+  background-color: #444654;
+}
+
+.accesorios-container {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.search-section {
+  width: 40%;
+  min-width: 250px;
+}
+
+.table-section {
+  flex: 1;
+}
+
+.search-container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.search-container .material-icons {
+  margin-right: 0.5rem;
+  color: #fff;
+}
+
+.search-container input {
+  padding: 0.75rem;
+  border-radius: 4px;
+  border: 1px solid #565869;
+  background-color: #343541;
+  color: #fff;
+  flex: 1;
+}
+
+.results {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border: 1px solid #565869;
+  border-radius: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.results li {
+  padding: 0.5rem;
+  cursor: pointer;
+}
+
+.results li:hover {
+  background-color: #444654;
+}

--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -1,1 +1,37 @@
 <h2>Accesorios</h2>
+<div class="accesorios-container">
+  <div class="search-section">
+    <div class="search-container">
+      <span class="material-icons">search</span>
+      <input
+        type="text"
+        placeholder="Buscar materiales"
+        [(ngModel)]="searchText"
+        (input)="onSearchChange()"
+      />
+    </div>
+    <ul class="results" *ngIf="results.length">
+      <li *ngFor="let mat of results" (click)="addMaterial(mat)">
+        {{ mat.name }}
+      </li>
+    </ul>
+  </div>
+  <div class="table-section">
+    <table *ngIf="selected.length">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Nombre</th>
+          <th>Descripción</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let mat of selected">
+          <td>{{ mat.id }}</td>
+          <td>{{ mat.name }}</td>
+          <td>{{ mat.description }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -1,8 +1,41 @@
 import { Component } from '@angular/core';
+import { MaterialService, Material } from '../services/material.service';
 
 @Component({
   selector: 'app-accesorios',
   templateUrl: './accesorios.component.html',
   styleUrls: ['./accesorios.component.css']
 })
-export class AccesoriosComponent {}
+export class AccesoriosComponent {
+  searchText = '';
+  results: Material[] = [];
+  selected: Material[] = [];
+  searching = false;
+
+  constructor(private materialService: MaterialService) {}
+
+  onSearchChange(): void {
+    if (this.searchText.trim() === '') {
+      this.results = [];
+      return;
+    }
+    this.searching = true;
+    this.materialService.getMaterials(1, 10, this.searchText).subscribe({
+      next: res => {
+        const docs: any = (res as any).docs ?? (res as any).items ?? res;
+        this.results = Array.isArray(docs) ? docs : [];
+        this.searching = false;
+      },
+      error: () => {
+        this.results = [];
+        this.searching = false;
+      }
+    });
+  }
+
+  addMaterial(mat: Material): void {
+    if (!this.selected.some(m => m.id === mat.id)) {
+      this.selected.push(mat);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement search in accessories using `MaterialService`
- show search results and add selected items to a table
- style accessories search and table

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f97eede4832d8c3cd3e0b3775a25