### PR TITLE
Fix accessory search field clearing

### DIFF
--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { AccesoriosComponent } from './accesorios.component';
+import { MaterialService } from '../services/material.service';
+import { CookieService } from '../services/cookie.service';
+
+describe('AccesoriosComponent', () => {
+  let component: AccesoriosComponent;
+  let fixture: ComponentFixture<AccesoriosComponent>;
+  let materialServiceSpy: jasmine.SpyObj<MaterialService>;
+
+  beforeEach(() => {
+    materialServiceSpy = jasmine.createSpyObj('MaterialService', ['getMaterials']);
+    TestBed.configureTestingModule({
+      declarations: [AccesoriosComponent],
+      imports: [FormsModule],
+      providers: [CookieService, { provide: MaterialService, useValue: materialServiceSpy }],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+
+    fixture = TestBed.createComponent(AccesoriosComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should add material and clear search', () => {
+    const mat = { id: 1, name: 'Mat', description: 'Desc' } as any;
+    component.results = [mat];
+    component.searchText = 'ma';
+
+    component.addMaterial(mat);
+
+    expect(component.selected).toContain(mat);
+    expect(component.searchText).toBe('');
+    expect(component.results).toEqual([]);
+  });
+});

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -36,6 +36,8 @@ export class AccesoriosComponent {
   addMaterial(mat: Material): void {
     if (!this.selected.some(m => m.id === mat.id)) {
       this.selected.push(mat);
+      this.searchText = '';
+      this.results = [];
     }
   }
 }


### PR DESCRIPTION
## Summary
- clear search field and results once an accessory is selected
- add unit test for the accessory component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859fe7e6488832d99f8224cf8bcbaa9