### PR TITLE
Add material type selector with search

### DIFF
--- a/src/app/listado-materiales/listado-materiales.component.html
+++ b/src/app/listado-materiales/listado-materiales.component.html
@@ -102,15 +102,20 @@
         </div>
       </div>
       <div class="form-group">
-        <label for="mat-type">Tipo ID</label>
+        <label for="mat-type">Tipo</label>
         <input
           id="mat-type"
-          type="number"
-          [(ngModel)]="newMaterial.material_type_id"
+          type="text"
+          list="materialTypeOptions"
+          [ngModel]="newMaterial.material_type_id"
+          (ngModelChange)="newMaterial.material_type_id = parseNumber($event)"
           name="material_type_id"
           required
           #typeRef="ngModel"
         />
+        <datalist id="materialTypeOptions">
+          <option *ngFor="let t of materialTypes" [value]="t.id">{{ t.name }}</option>
+        </datalist>
         <div class="error" *ngIf="typeRef.touched && typeRef.hasError('required')">
           El tipo es requerido
         </div>
@@ -184,15 +189,20 @@
         </div>
       </div>
       <div class="form-group">
-        <label for="edit-type">Tipo ID</label>
+        <label for="edit-type">Tipo</label>
         <input
           id="edit-type"
-          type="number"
-          [(ngModel)]="editMaterialData.material_type_id"
+          type="text"
+          list="editMaterialTypeOptions"
+          [ngModel]="editMaterialData.material_type_id"
+          (ngModelChange)="editMaterialData.material_type_id = parseNumber($event)"
           name="material_type_id"
           required
           #editTypeRef="ngModel"
         />
+        <datalist id="editMaterialTypeOptions">
+          <option *ngFor="let t of materialTypes" [value]="t.id">{{ t.name }}</option>
+        </datalist>
         <div class="error" *ngIf="editTypeRef.touched && editTypeRef.hasError('required')">
           El tipo es requerido
         </div>

--- a/src/app/listado-materiales/listado-materiales.component.spec.ts
+++ b/src/app/listado-materiales/listado-materiales.component.spec.ts
@@ -4,6 +4,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ListadoMaterialesComponent } from './listado-materiales.component';
 import { MaterialService } from '../services/material.service';
+import { MaterialTypeService } from '../services/material-type.service';
 import { CookieService } from '../services/cookie.service';
 import { environment } from '../../environments/environment';
 
@@ -16,7 +17,7 @@ describe('ListadoMaterialesComponent', () => {
     TestBed.configureTestingModule({
       declarations: [ListadoMaterialesComponent],
       imports: [HttpClientTestingModule, FormsModule],
-      providers: [MaterialService, CookieService],
+      providers: [MaterialService, MaterialTypeService, CookieService],
       schemas: [NO_ERRORS_SCHEMA]
     });
 

--- a/src/app/listado-materiales/listado-materiales.component.ts
+++ b/src/app/listado-materiales/listado-materiales.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { MaterialService, Material, NewMaterial } from '../services/material.service';
+import { MaterialTypeService, MaterialType } from '../services/material-type.service';
 
 @Component({
   selector: 'app-listado-materiales',
@@ -19,6 +20,7 @@ export class ListadoMaterialesComponent implements OnInit {
   searchText = '';
   showAddModal = false;
   showEditModal = false;
+  materialTypes: MaterialType[] = [];
   editingMaterialId: number | null = null;
   editMaterialData: NewMaterial = {
     name: '',
@@ -43,10 +45,14 @@ export class ListadoMaterialesComponent implements OnInit {
   isSaving = false;
   isUpdating = false;
 
-  constructor(private materialService: MaterialService) {}
+  constructor(
+    private materialService: MaterialService,
+    private materialTypeService: MaterialTypeService
+  ) {}
 
   ngOnInit(): void {
     this.loadMaterials();
+    this.loadMaterialTypes();
   }
 
   private loadMaterials(): void {
@@ -71,6 +77,22 @@ export class ListadoMaterialesComponent implements OnInit {
           this.errorMessage = 'Error al cargar los materiales';
         }
       });
+  }
+
+  private loadMaterialTypes(): void {
+    this.materialTypeService.getMaterialTypes().subscribe({
+      next: types => {
+        this.materialTypes = Array.isArray(types) ? types : [];
+      },
+      error: err => {
+        console.error('Failed to load material types', err);
+      }
+    });
+  }
+
+  parseNumber(value: string): number | undefined {
+    const n = parseInt(value, 10);
+    return isNaN(n) ? undefined : n;
   }
 
   openAddModal(): void {

--- a/src/app/services/material-type.service.ts
+++ b/src/app/services/material-type.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { CookieService } from './cookie.service';
+import { environment } from '../../environments/environment';
+
+export interface MaterialType {
+  id: number;
+  name: string;
+  unit: string;
+  description: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MaterialTypeService {
+  constructor(private http: HttpClient, private cookieService: CookieService) {}
+
+  private httpOptions() {
+    const token = this.cookieService.get('token');
+    return token
+      ? { headers: new HttpHeaders({ token }), withCredentials: true }
+      : { withCredentials: true };
+  }
+
+  getMaterialTypes(): Observable<MaterialType[]> {
+    return this.http.get<MaterialType[]>(
+      `${environment.apiUrl}/material-types`,
+      this.httpOptions()
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- fetch material types from the API
- let users pick material type using a searchable datalist
- wire up the new service into material list component
- adjust specs for new dependency

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a07615320832d87afb125d7bdff79