### PR TITLE
Add area cost inputs in accesorios

### DIFF
--- a/src/app/accesorios/accesorios.component.css
+++ b/src/app/accesorios/accesorios.component.css
@@ -92,6 +92,16 @@ th {
   background-color: #444654;
 }
 
+.dim-input {
+  width: 70px;
+  margin-right: 0.25rem;
+  padding: 0.25rem;
+  border-radius: 4px;
+  border: 1px solid #565869;
+  background-color: #343541;
+  color: #fff;
+}
+
 nav.breadcrumb,
 .breadcrumb {
   font-size: 0.85rem;

--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -23,21 +23,45 @@
         <tr>
           <th>Nombre</th>
           <th>Descripción</th>
+          <th>Tipo</th>
+          <th>Costo por tipo seleccionado</th>
           <th>Inversión</th>
           <th></th>
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let mat of selected">
-          <td>{{ mat.name }}</td>
-          <td>{{ mat.description }}</td>
-          <td>{{ mat.price }}</td>
+        <tr *ngFor="let sel of selected">
+          <td>{{ sel.material.name }}</td>
+          <td>{{ sel.material.description }}</td>
+          <td>
+            <ng-container *ngIf="isAreaType(sel.material); else typeName">
+              <input
+                type="number"
+                min="0"
+                class="dim-input"
+                [(ngModel)]="sel.length"
+                placeholder="Largo"
+              />
+              <input
+                type="number"
+                min="0"
+                class="dim-input"
+                [(ngModel)]="sel.width"
+                placeholder="Ancho"
+              />
+            </ng-container>
+            <ng-template #typeName>
+              {{ getMaterialType(sel.material)?.name }}
+            </ng-template>
+          </td>
+          <td>{{ calculateCost(sel) | number:'1.2-2' }}</td>
+          <td>{{ sel.material.price }}</td>
           <td>
             <button
               type="button"
               class="delete-btn"
               title="Quitar"
-              (click)="removeMaterial(mat)"
+              (click)="removeMaterial(sel)"
             >
               <span class="material-icons" aria-hidden="true">delete</span>
             </button>


### PR DESCRIPTION
## Summary
- pull material types when rendering accesorios
- treat materials with area units specially by collecting width/length
- calculate cost from area and material price
- show type inputs and cost per selected type in the accessories table
- style measurement inputs

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a11b34570832db0c9585dbd94e82f