### PR TITLE
Adjust accessories fields for piece/area types

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -34,7 +34,7 @@
           <td>{{ sel.material.name }}</td>
           <td>{{ sel.material.description }}</td>
           <td>
-            <ng-container *ngIf="isAreaType(sel.material); else typeName">
+            <ng-container *ngIf="isAreaType(sel.material); else otherType">
               <input
                 type="number"
                 min="0"
@@ -50,8 +50,19 @@
                 placeholder="Ancho"
               />
             </ng-container>
-            <ng-template #typeName>
-              {{ getMaterialType(sel.material)?.name }}
+            <ng-template #otherType>
+              <ng-container *ngIf="isPieceType(sel.material); else typeName">
+                <input
+                  type="number"
+                  min="0"
+                  class="dim-input"
+                  [(ngModel)]="sel.quantity"
+                  placeholder="Piezas"
+                />
+              </ng-container>
+              <ng-template #typeName>
+                {{ getMaterialType(sel.material)?.name }}
+              </ng-template>
             </ng-template>
           </td>
           <td>{{ calculateCost(sel) | number:'1.2-2' }}</td>

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -6,6 +6,7 @@ interface SelectedMaterial {
   material: Material;
   width?: number;
   length?: number;
+  quantity?: number;
 }
 
 @Component({
@@ -77,21 +78,25 @@ export class AccesoriosComponent implements OnInit {
 
   isAreaType(mat: Material): boolean {
     const type = this.getMaterialType(mat);
-    if (!type || !type.unit) {
-      return false;
-    }
-    const u = type.unit.toLowerCase();
-    return u.includes('m2') || u.includes('m²') || u.includes('area');
+    return type?.id === 2;
+  }
+
+  isPieceType(mat: Material): boolean {
+    const type = this.getMaterialType(mat);
+    return type?.id === 1;
   }
 
   calculateCost(sel: SelectedMaterial): number {
+    const price = sel.material.price ?? 0;
     if (this.isAreaType(sel.material)) {
       const width = sel.width ?? 0;
       const length = sel.length ?? 0;
-      const area = width * length;
-      const price = sel.material.price ?? 0;
-      return area * price;
+      return width * length * price;
     }
-    return sel.material.price ?? 0;
+    if (this.isPieceType(sel.material)) {
+      const qty = sel.quantity ?? 0;
+      return qty * price;
+    }
+    return price;
   }
 }


### PR DESCRIPTION
## Summary
- allow accessory rows to capture quantity for piece type materials
- calculate investment based on quantity or area

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a157d8be4832db41d6e3bb3592fbc