### PR TITLE
Fix accessory cost ratio

### DIFF
--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -35,4 +35,48 @@ describe('AccesoriosComponent', () => {
     expect(component.searchText).toBe('');
     expect(component.results).toEqual([]);
   });
+
+  it('should calculate area cost relative to base size', () => {
+    const mat = {
+      id: 1,
+      name: 'Madera',
+      description: 'Sheet',
+      material_type_id: 2,
+      price: 1001,
+      width_m: 1.22,
+      length_m: 2.44
+    } as any;
+
+    component.materialTypes = [
+      { id: 2, name: 'Area', unit: 'm2', description: '' } as any
+    ];
+
+    const sel: any = { material: mat, width: 1.22, length: 2.44 };
+
+    const cost = component.calculateCost(sel);
+
+    expect(cost).toBeCloseTo(1001, 2);
+  });
+
+  it('should fallback to simple area cost when base is missing', () => {
+    const mat = {
+      id: 2,
+      name: 'Madera',
+      description: 'Sheet',
+      material_type_id: 2,
+      price: 100,
+      width_m: undefined,
+      length_m: undefined
+    } as any;
+
+    component.materialTypes = [
+      { id: 2, name: 'Area', unit: 'm2', description: '' } as any
+    ];
+
+    const sel: any = { material: mat, width: 2, length: 3 };
+
+    const cost = component.calculateCost(sel);
+
+    expect(cost).toBeCloseTo(600, 2);
+  });
 });

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -91,7 +91,14 @@ export class AccesoriosComponent implements OnInit {
     if (this.isAreaType(sel.material)) {
       const width = sel.width ?? 0;
       const length = sel.length ?? 0;
-      return width * length * price;
+      const baseWidth = sel.material.width_m ?? 0;
+      const baseLength = sel.material.length_m ?? 0;
+      const baseArea = baseWidth * baseLength;
+      const area = width * length;
+      if (baseArea > 0) {
+        return (area / baseArea) * price;
+      }
+      return area * price;
     }
     if (this.isPieceType(sel.material)) {
       const qty = sel.quantity ?? 0;


### PR DESCRIPTION
## Summary
- account for base sheet dimensions when calculating accessory area cost
- add specs for `calculateCost` logic

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a16fe5af8832d8d6348ca9c8c99e8