### PR TITLE
Add summary table for accessories

### DIFF
--- a/src/app/accesorios/accesorios.component.css
+++ b/src/app/accesorios/accesorios.component.css
@@ -92,6 +92,28 @@ th {
   background-color: #444654;
 }
 
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.summary-table th,
+.summary-table td {
+  padding: 0.5rem;
+}
+
+.summary-table tbody tr:not(:last-child) td {
+  border-bottom: 1px solid #565869;
+}
+
+.summary-table th {
+  background-color: #444654;
+  text-align: left;
+}
+
 .dim-input {
   width: 70px;
   margin-right: 0.25rem;

--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -16,6 +16,23 @@
         {{ mat.name }}
       </li>
     </ul>
+
+    <table class="summary-table">
+      <tbody>
+        <tr>
+          <th>Total materiales</th>
+          <td>{{ totalCost | number:'1.2-2' }}</td>
+        </tr>
+        <tr>
+          <th>Porcentaje de ganancia</th>
+          <td>{{ profitPercentage | number:'1.2-2' }}%</td>
+        </tr>
+        <tr>
+          <th>Total + ganancia</th>
+          <td>{{ totalWithProfit | number:'1.2-2' }}</td>
+        </tr>
+      </tbody>
+    </table>
   </div>
   <div class="table-section">
     <table *ngIf="selected.length">

--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -4,19 +4,26 @@ import { FormsModule } from '@angular/forms';
 
 import { AccesoriosComponent } from './accesorios.component';
 import { MaterialService } from '../services/material.service';
+import { MaterialTypeService } from '../services/material-type.service';
 import { CookieService } from '../services/cookie.service';
 
 describe('AccesoriosComponent', () => {
   let component: AccesoriosComponent;
   let fixture: ComponentFixture<AccesoriosComponent>;
   let materialServiceSpy: jasmine.SpyObj<MaterialService>;
+  let materialTypeServiceSpy: jasmine.SpyObj<MaterialTypeService>;
 
   beforeEach(() => {
     materialServiceSpy = jasmine.createSpyObj('MaterialService', ['getMaterials']);
+    materialTypeServiceSpy = jasmine.createSpyObj('MaterialTypeService', ['getMaterialTypes']);
     TestBed.configureTestingModule({
       declarations: [AccesoriosComponent],
       imports: [FormsModule],
-      providers: [CookieService, { provide: MaterialService, useValue: materialServiceSpy }],
+      providers: [
+        CookieService,
+        { provide: MaterialService, useValue: materialServiceSpy },
+        { provide: MaterialTypeService, useValue: materialTypeServiceSpy }
+      ],
       schemas: [NO_ERRORS_SCHEMA]
     });
 

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { MaterialService, Material } from '../services/material.service';
 import { MaterialTypeService, MaterialType } from '../services/material-type.service';
+import { CookieService } from '../services/cookie.service';
 
 interface SelectedMaterial {
   material: Material;
@@ -21,13 +22,26 @@ export class AccesoriosComponent implements OnInit {
   selected: SelectedMaterial[] = [];
   materialTypes: MaterialType[] = [];
   searching = false;
+  profitPercentage = 0;
 
   constructor(
     private materialService: MaterialService,
-    private materialTypeService: MaterialTypeService
+    private materialTypeService: MaterialTypeService,
+    private cookieService: CookieService
   ) {}
 
   ngOnInit(): void {
+    const loginData = this.cookieService.get('loginData');
+    if (loginData) {
+      try {
+        const data = JSON.parse(loginData);
+        if (typeof data.profit_percentage === 'number') {
+          this.profitPercentage = data.profit_percentage;
+        }
+      } catch (_) {
+        // ignore parse errors
+      }
+    }
     this.materialTypeService.getMaterialTypes().subscribe({
       next: types => {
         this.materialTypes = Array.isArray(types) ? types : [];
@@ -105,5 +119,13 @@ export class AccesoriosComponent implements OnInit {
       return qty * price;
     }
     return price;
+  }
+
+  get totalCost(): number {
+    return this.selected.reduce((sum, sel) => sum + this.calculateCost(sel), 0);
+  }
+
+  get totalWithProfit(): number {
+    return this.totalCost * (1 + this.profitPercentage / 100);
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,7 @@ interface LoginResponse {
   token: string;
   user: { id: number; username: string };
   ownerCompany: { id: number; name: string };
+  profit_percentage: number;
 }
 
 @Component({


### PR DESCRIPTION
## Summary
- include profit_percentage in LoginResponse
- show selected total, profit percentage and total with profit in accessories
- adjust accessories styles for summary table
- fix accessories unit tests

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: cannot find module '@angular/core')*

------
https://chatgpt.com/codex/tasks/task_e_685a18767aa4832db8cdae268632dfcc