### PR TITLE
Improve delete confirmation UX

### DIFF
--- a/src/app/accesorios/accesorios.component.css
+++ b/src/app/accesorios/accesorios.component.css
@@ -108,3 +108,48 @@ nav.breadcrumb,
   color: #888;
   margin-bottom: 0.5rem;
 }
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.confirm-modal {
+  background-color: #444654;
+  padding: 1.5rem;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 300px;
+  position: relative;
+  color: #e8e8e8;
+  text-align: center;
+}
+
+.confirm-modal .close-icon {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 1rem;
+}
+
+.cancel-btn {
+  background-color: #e53e3e;
+}
+
+.cancel-btn:hover {
+  background-color: #c53030;
+}

--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -72,7 +72,7 @@
               type="button"
               class="delete-btn"
               title="Quitar"
-              (click)="removeMaterial(sel)"
+              (click)="openRemoveModal(sel)"
             >
               <span class="material-icons" aria-hidden="true">delete</span>
             </button>
@@ -80,5 +80,16 @@
         </tr>
       </tbody>
     </table>
+  </div>
+</div>
+
+<div class="modal-overlay" *ngIf="showRemoveModal" (mousedown)="closeRemoveModal()">
+  <div class="confirm-modal" (mousedown)="$event.stopPropagation()" (click)="$event.stopPropagation()">
+    <span class="close-icon material-icons" (click)="closeRemoveModal()">close</span>
+    <p>¿Quitar material?</p>
+    <div class="modal-actions">
+      <button type="button" (click)="confirmRemove()">Quitar</button>
+      <button type="button" class="cancel-btn" (click)="closeRemoveModal()">Cancelar</button>
+    </div>
   </div>
 </div>

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -21,6 +21,8 @@ export class AccesoriosComponent implements OnInit {
   selected: SelectedMaterial[] = [];
   materialTypes: MaterialType[] = [];
   searching = false;
+  showRemoveModal = false;
+  materialToRemove: SelectedMaterial | null = null;
 
   constructor(
     private materialService: MaterialService,
@@ -65,11 +67,23 @@ export class AccesoriosComponent implements OnInit {
     }
   }
 
-  removeMaterial(sel: SelectedMaterial): void {
-    const confirmed = window.confirm('Quitar?');
-    if (confirmed) {
-      this.selected = this.selected.filter(m => m.material.id !== sel.material.id);
+  openRemoveModal(sel: SelectedMaterial): void {
+    this.materialToRemove = sel;
+    this.showRemoveModal = true;
+  }
+
+  closeRemoveModal(): void {
+    this.showRemoveModal = false;
+    this.materialToRemove = null;
+  }
+
+  confirmRemove(): void {
+    if (this.materialToRemove) {
+      this.selected = this.selected.filter(
+        m => m.material.id !== this.materialToRemove!.material.id
+      );
     }
+    this.closeRemoveModal();
   }
 
   getMaterialType(mat: Material): MaterialType | undefined {


### PR DESCRIPTION
## Summary
- replace alert confirmation with a custom modal in the accessories page

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a189ef544832d8558d2633bb0d733