### PR TITLE
Fix profit percentage parsing in accessories

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -35,8 +35,12 @@ export class AccesoriosComponent implements OnInit {
     if (loginData) {
       try {
         const data = JSON.parse(loginData);
-        if (typeof data.profit_percentage === 'number') {
-          this.profitPercentage = data.profit_percentage;
+        const profit =
+          typeof data.profit_percentage === 'number'
+            ? data.profit_percentage
+            : parseFloat(data.profit_percentage);
+        if (!Number.isNaN(profit)) {
+          this.profitPercentage = profit;
         }
       } catch (_) {
         // ignore parse errors


### PR DESCRIPTION
## Summary
- parse numeric string values when reading `profit_percentage`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a19c23f3c832dac304739adf35f4d