### PR TITLE
Fix profit percentage retrieval

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -37,10 +37,19 @@ export class AccesoriosComponent implements OnInit {
     if (loginData) {
       try {
         const data = JSON.parse(loginData);
-        const profit =
-          typeof data.profit_percentage === 'number'
-            ? data.profit_percentage
-            : parseFloat(data.profit_percentage);
+        let profit = 0;
+        if (typeof data.profit_percentage === 'number') {
+          profit = data.profit_percentage;
+        } else if (data.profit_percentage !== undefined) {
+          profit = parseFloat(data.profit_percentage);
+        } else if (
+          data.ownerCompany &&
+          typeof data.ownerCompany.profit_percentage === 'number'
+        ) {
+          profit = data.ownerCompany.profit_percentage;
+        } else if (data.ownerCompany?.profit_percentage !== undefined) {
+          profit = parseFloat(data.ownerCompany.profit_percentage);
+        }
         if (!Number.isNaN(profit)) {
           this.profitPercentage = profit;
         }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,8 +8,11 @@ interface LoginResponse {
   message: string;
   token: string;
   user: { id: number; username: string };
-  ownerCompany: { id: number; name: string };
-  profit_percentage: number;
+  ownerCompany: {
+    id: number;
+    name: string;
+    profit_percentage: number;
+  };
 }
 
 @Component({


### PR DESCRIPTION
## Summary
- adjust LoginResponse interface to match backend
- parse profit percentage from nested `ownerCompany` in Accesorios

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1aeeffdc832d8a8ed6aadb604f2f