### PR TITLE
Add accessory creation form

### DIFF
--- a/src/app/accesorios/accesorios.component.css
+++ b/src/app/accesorios/accesorios.component.css
@@ -175,3 +175,57 @@ nav.breadcrumb,
 .cancel-btn:hover {
   background-color: #c53030;
 }
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.form-group input,
+.form-group textarea {
+  padding: 0.75rem;
+  border-radius: 4px;
+  border: 1px solid #565869;
+  background-color: #343541;
+  color: #fff;
+}
+
+.form-group input.ng-invalid.ng-touched,
+.form-group textarea.ng-invalid.ng-touched {
+  border-color: #ff6b6b;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 1rem;
+  position: relative;
+}
+
+.loader-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #10a37f;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -1,6 +1,34 @@
 <nav class="breadcrumb">Inicio / Accesorios</nav>
 <h2>Accesorios</h2>
-<div class="accesorios-container">
+<form #accForm="ngForm" (ngSubmit)="submitAccessory(accForm)">
+  <div class="form-group">
+    <label for="acc-name">Nombre</label>
+    <input
+      id="acc-name"
+      type="text"
+      [(ngModel)]="accessoryName"
+      name="name"
+      required
+      #nameRef="ngModel"
+    />
+    <div class="error" *ngIf="nameRef.touched && nameRef.invalid">
+      El nombre es requerido
+    </div>
+  </div>
+  <div class="form-group">
+    <label for="acc-desc">Descripción</label>
+    <textarea
+      id="acc-desc"
+      [(ngModel)]="accessoryDescription"
+      name="description"
+      required
+      #descRef="ngModel"
+    ></textarea>
+    <div class="error" *ngIf="descRef.touched && descRef.invalid">
+      La descripción es requerida
+    </div>
+  </div>
+  <div class="accesorios-container">
   <div class="search-section">
     <div class="search-container">
       <span class="material-icons">search</span>
@@ -98,7 +126,15 @@
       </tbody>
     </table>
   </div>
-</div>
+  </div>
+  <div class="error" *ngIf="saveError">{{ saveError }}</div>
+  <div class="form-actions">
+    <button type="submit" [disabled]="isSaving || !accForm.form.valid">Confirmar</button>
+    <div class="loader-overlay" *ngIf="isSaving">
+      <div class="spinner"></div>
+    </div>
+  </div>
+</form>
 
 <div class="modal-overlay" *ngIf="showRemoveModal" (mousedown)="closeRemoveModal()">
   <div class="confirm-modal" (mousedown)="$event.stopPropagation()" (click)="$event.stopPropagation()">

--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -6,23 +6,27 @@ import { AccesoriosComponent } from './accesorios.component';
 import { MaterialService } from '../services/material.service';
 import { MaterialTypeService } from '../services/material-type.service';
 import { CookieService } from '../services/cookie.service';
+import { AccessoryService } from '../services/accessory.service';
 
 describe('AccesoriosComponent', () => {
   let component: AccesoriosComponent;
   let fixture: ComponentFixture<AccesoriosComponent>;
   let materialServiceSpy: jasmine.SpyObj<MaterialService>;
   let materialTypeServiceSpy: jasmine.SpyObj<MaterialTypeService>;
+  let accessoryServiceSpy: jasmine.SpyObj<AccessoryService>;
 
   beforeEach(() => {
     materialServiceSpy = jasmine.createSpyObj('MaterialService', ['getMaterials']);
     materialTypeServiceSpy = jasmine.createSpyObj('MaterialTypeService', ['getMaterialTypes']);
+    accessoryServiceSpy = jasmine.createSpyObj('AccessoryService', ['addAccessory', 'addAccessoryMaterials']);
     TestBed.configureTestingModule({
       declarations: [AccesoriosComponent],
       imports: [FormsModule],
       providers: [
         CookieService,
         { provide: MaterialService, useValue: materialServiceSpy },
-        { provide: MaterialTypeService, useValue: materialTypeServiceSpy }
+        { provide: MaterialTypeService, useValue: materialTypeServiceSpy },
+        { provide: AccessoryService, useValue: accessoryServiceSpy }
       ],
       schemas: [NO_ERRORS_SCHEMA]
     });

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { CookieService } from './cookie.service';
+
+export interface Accessory {
+  id: number;
+  name: string;
+  description: string;
+  owner_id?: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface AccessoryMaterial {
+  accessory_id: number;
+  material_id: number;
+  width?: number;
+  length?: number;
+  quantity?: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AccessoryService {
+  constructor(private http: HttpClient, private cookieService: CookieService) {}
+
+  private httpOptions() {
+    const token = this.cookieService.get('token');
+    return token
+      ? { headers: new HttpHeaders({ token }), withCredentials: true }
+      : { withCredentials: true };
+  }
+
+  addAccessory(
+    name: string,
+    description: string,
+    ownerId: number
+  ): Observable<Accessory> {
+    const body = { name, description, owner_id: ownerId };
+    return this.http.post<Accessory>(
+      `${environment.apiUrl}/accessories`,
+      body,
+      this.httpOptions()
+    );
+  }
+
+  addAccessoryMaterials(
+    accessoryId: number,
+    materials: AccessoryMaterial[]
+  ): Observable<any> {
+    const body = { accessory_id: accessoryId, materials };
+    return this.http.post<any>(
+      `${environment.apiUrl}/accessories-materials`,
+      body,
+      this.httpOptions()
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add AccessoryService for API interaction
- extend Accesorios component with creation form and submit handler
- adjust Accesorios tests to include AccessoryService
- style accessory form elements

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e3721390832d92cbb239e1792fa2