### PR TITLE
Fix material search within accessory form

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -30,15 +30,17 @@
   </div>
   <div class="accesorios-container">
   <div class="search-section">
-    <div class="search-container">
-      <span class="material-icons">search</span>
-      <input
-        type="text"
-        placeholder="Buscar materiales"
-        [(ngModel)]="searchText"
-        (input)="onSearchChange()"
-      />
-    </div>
+      <div class="search-container">
+        <span class="material-icons">search</span>
+        <input
+          type="text"
+          placeholder="Buscar materiales"
+          [(ngModel)]="searchText"
+          name="search"
+          [ngModelOptions]="{ standalone: true }"
+          (input)="onSearchChange()"
+        />
+      </div>
     <ul class="results" *ngIf="results.length">
       <li *ngFor="let mat of results" (click)="addMaterial(mat)">
         {{ mat.name }}


### PR DESCRIPTION
## Summary
- fix accessory material search input by making it standalone

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e56dff60832db3ad8aa5a838b63b