### PR TITLE
Fix accessory form validation

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -175,6 +175,19 @@ export class AccesoriosComponent implements OnInit {
       form.form.markAllAsTouched();
       return;
     }
+    // Ensure name and description are not just whitespace
+    if (this.accessoryName.trim() === '') {
+      const control = form.form.controls['name'];
+      control?.setErrors({ required: true });
+      control?.markAsTouched();
+      return;
+    }
+    if (this.accessoryDescription.trim() === '') {
+      const control = form.form.controls['description'];
+      control?.setErrors({ required: true });
+      control?.markAsTouched();
+      return;
+    }
     if (this.selected.length === 0) {
       this.saveError = 'Debes seleccionar al menos un material';
       return;


### PR DESCRIPTION
## Summary
- ensure accessory name and description are not blank or whitespace-only

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e7a2bf10832dbcc40cf7d2dbf9d4