### PR TITLE
Fix accessory form validation

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -9,9 +9,16 @@
       [(ngModel)]="accessoryName"
       name="name"
       required
+      pattern=".*\S.*"
       #nameRef="ngModel"
     />
-    <div class="error" *ngIf="nameRef.touched && nameRef.invalid">
+    <div
+      class="error"
+      *ngIf="
+        nameRef.touched &&
+        (nameRef.hasError('required') || nameRef.hasError('pattern'))
+      "
+    >
       El nombre es requerido
     </div>
   </div>
@@ -22,9 +29,16 @@
       [(ngModel)]="accessoryDescription"
       name="description"
       required
+      pattern=".*\S.*"
       #descRef="ngModel"
     ></textarea>
-    <div class="error" *ngIf="descRef.touched && descRef.invalid">
+    <div
+      class="error"
+      *ngIf="
+        descRef.touched &&
+        (descRef.hasError('required') || descRef.hasError('pattern'))
+      "
+    >
       La descripción es requerida
     </div>
   </div>
@@ -134,7 +148,12 @@
   </div>
   <div class="error" *ngIf="saveError">{{ saveError }}</div>
   <div class="form-actions">
-    <button type="submit" [disabled]="isSaving || !accForm.form.valid">Confirmar</button>
+    <button
+      type="submit"
+      [disabled]="isSaving || !accForm.form.valid || selected.length === 0"
+    >
+      Confirmar
+    </button>
     <div class="loader-overlay" *ngIf="isSaving">
       <div class="spinner"></div>
     </div>

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -175,19 +175,7 @@ export class AccesoriosComponent implements OnInit {
       form.form.markAllAsTouched();
       return;
     }
-    // Ensure name and description are not just whitespace
-    if (this.accessoryName.trim() === '') {
-      const control = form.form.controls['name'];
-      control?.setErrors({ required: true });
-      control?.markAsTouched();
-      return;
-    }
-    if (this.accessoryDescription.trim() === '') {
-      const control = form.form.controls['description'];
-      control?.setErrors({ required: true });
-      control?.markAsTouched();
-      return;
-    }
+    // Prevent saving without selecting any material
     if (this.selected.length === 0) {
       this.saveError = 'Debes seleccionar al menos un material';
       return;
@@ -208,9 +196,11 @@ export class AccesoriosComponent implements OnInit {
       return;
     }
 
+    const name = this.accessoryName.trim();
+    const description = this.accessoryDescription.trim();
     this.isSaving = true;
     this.accessoryService
-      .addAccessory(this.accessoryName, this.accessoryDescription, ownerId)
+      .addAccessory(name, description, ownerId)
       .subscribe({
         next: (acc: Accessory) => {
           const materials: AccessoryMaterial[] = this.selected.map(sel => ({


### PR DESCRIPTION
## Summary
- require non-whitespace text in accessory name and description
- disable submit button when no materials are selected
- trim accessory name and description before saving

## Testing
- `npm test` *(fails: ng not found)*
- `npx ng test --watch=false` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6862e8d814a0832d9e76ead027419fd1