### PR TITLE
Fix validation for accessory form

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -150,7 +150,7 @@
   <div class="form-actions">
     <button
       type="submit"
-      [disabled]="isSaving || !accForm.form.valid || selected.length === 0"
+      [disabled]="isSaving"
     >
       Confirmar
     </button>


### PR DESCRIPTION
## Summary
- allow clicking the confirm button even when the form is incomplete so that errors appear

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e9f70628832d93e848fe72229edb