### PR TITLE
Include cost and price when saving accessory materials

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -242,13 +242,19 @@ export class AccesoriosComponent implements OnInit {
       .addAccessory(name, description, ownerId)
       .subscribe({
         next: (acc: Accessory) => {
-          const materials: AccessoryMaterial[] = this.selected.map(sel => ({
-            accessory_id: acc.id,
-            material_id: sel.material.id,
-            width: sel.width,
-            length: sel.length,
-            quantity: sel.quantity
-          }));
+          const materials: AccessoryMaterial[] = this.selected.map(sel => {
+            const cost = this.calculateCost(sel);
+            return {
+              accessory_id: acc.id,
+              material_id: sel.material.id,
+              width: sel.width,
+              length: sel.length,
+              quantity: sel.quantity,
+              cost,
+              price: cost * (1 + this.profitPercentage / 100),
+              profit_percentage: this.profitPercentage
+            };
+          });
           this.accessoryService
             .addAccessoryMaterials(acc.id, materials)
             .subscribe({

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -19,6 +19,9 @@ export interface AccessoryMaterial {
   width?: number;
   length?: number;
   quantity?: number;
+  cost?: number;
+  price?: number;
+  profit_percentage?: number;
 }
 
 @Injectable({


### PR DESCRIPTION
## Summary
- extend `AccessoryMaterial` to include cost, price and profit percentage
- compute these values in `AccesoriosComponent.submitAccessory` before sending to the API

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module '@angular/core')*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ed34e93c832d8310221b87b2243a