### PR TITLE
Fix accessory materials endpoint

### DIFF
--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -56,7 +56,7 @@ export class AccessoryService {
   ): Observable<any> {
     const body = { accessory_id: accessoryId, materials };
     return this.http.post<any>(
-      `${environment.apiUrl}/accessories-materials`,
+      `${environment.apiUrl}/accessory-materials`,
       body,
       this.httpOptions()
     );


### PR DESCRIPTION
## Summary
- update AccessoryService to post to `/accessory-materials`

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f1244d74832d85809153e465a42d