### PR TITLE
Add monetary columns to accessory list

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -207,6 +207,8 @@
         <th>ID</th>
         <th>Nombre</th>
         <th>Descripción</th>
+        <th>Costo total</th>
+        <th>Precio total</th>
       </tr>
     </thead>
     <tbody>
@@ -214,6 +216,8 @@
         <td>{{ acc.id }}</td>
         <td>{{ acc.name }}</td>
         <td>{{ acc.description }}</td>
+        <td>{{ acc.cost }}</td>
+        <td>{{ acc.price }}</td>
       </tr>
     </tbody>
   </table>

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -8,6 +8,10 @@ export interface Accessory {
   id: number;
   name: string;
   description: string;
+  /** Total cost of materials without profit */
+  cost?: number;
+  /** Final price including profit percentage */
+  price?: number;
   owner_id?: number;
   created_at?: string;
   updated_at?: string;


### PR DESCRIPTION
## Summary
- extend Accessory interface to include `cost` and `price`
- display cost and price columns in the accessory list

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f48273b0832d8781a28a983998b8