### PR TITLE
Update accessories endpoint to use pagination

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -144,9 +144,10 @@ export class AccesoriosComponent implements OnInit {
       this.accessories = [];
       return;
     }
-    this.accessoryService.getAccessories(this.ownerId).subscribe({
-      next: accs => {
-        this.accessories = Array.isArray(accs) ? accs : [];
+    this.accessoryService.getAccessories(this.ownerId, 1, 10).subscribe({
+      next: res => {
+        const docs: any = (res as any).docs ?? (res as any).items ?? res;
+        this.accessories = Array.isArray(docs) ? docs : [];
       },
       error: () => {
         this.accessories = [];

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -28,6 +28,14 @@ export interface AccessoryMaterial {
   profit_percentage?: number;
 }
 
+export interface PaginatedAccessories {
+  docs: Accessory[];
+  totalDocs: number;
+  limit: number;
+  page: number;
+  totalPages: number;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -66,10 +74,22 @@ export class AccessoryService {
     );
   }
 
-  getAccessories(ownerId: number): Observable<Accessory[]> {
-    return this.http.get<Accessory[]>(
-      `${environment.apiUrl}/accessories?owner_id=${ownerId}`,
-      this.httpOptions()
-    );
+  getAccessories(
+    ownerId: number,
+    page?: number,
+    limit?: number
+  ): Observable<PaginatedAccessories> {
+    let url = `${environment.apiUrl}/accessories?owner_id=${ownerId}`;
+    const params: string[] = [];
+    if (page !== undefined) {
+      params.push(`page=${page}`);
+    }
+    if (limit !== undefined) {
+      params.push(`limit=${limit}`);
+    }
+    if (params.length) {
+      url += `&${params.join('&')}`;
+    }
+    return this.http.get<PaginatedAccessories>(url, this.httpOptions());
   }
 }


### PR DESCRIPTION
## Summary
- add PaginatedAccessories interface
- add pagination params to `AccessoryService.getAccessories`
- handle paginated response when listing accessories

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686313456f08832db156103b97e63827