### PR TITLE
Add search and pagination to accessories list

### DIFF
--- a/src/app/accesorios/accesorios.component.css
+++ b/src/app/accesorios/accesorios.component.css
@@ -253,3 +253,27 @@ nav.breadcrumb,
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+/* Pagination styles aligned with the platform colors */
+.pagination .page-link {
+  background-color: #444654;
+  color: #e8e8e8;
+  border: 1px solid #565869;
+}
+
+.pagination .page-link:hover {
+  background-color: #0e8a6e;
+  color: #fff;
+}
+
+.page-item.active .page-link {
+  background-color: #10a37f;
+  border-color: #10a37f;
+  color: #fff;
+}
+
+.page-item.disabled .page-link {
+  background-color: #343541;
+  color: #777;
+  border-color: #565869;
+}

--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -201,6 +201,15 @@
 </div>
 
 <div *ngIf="activeTab === 'list'" class="tab-pane">
+  <div class="search-container">
+    <span class="material-icons">search</span>
+    <input
+      type="text"
+      placeholder="Buscar accesorios"
+      [(ngModel)]="listSearchText"
+      (input)="onListSearchChange()"
+    />
+  </div>
   <table *ngIf="accessories.length">
     <thead>
       <tr>
@@ -221,5 +230,18 @@
       </tr>
     </tbody>
   </table>
+  <nav *ngIf="totalPages > 1" aria-label="Accessories pagination" class="mt-3">
+    <ul class="pagination justify-content-center">
+      <li class="page-item" [class.disabled]="currentPage === 1">
+        <a class="page-link" href="#" (click)="goToPage(currentPage - 1); $event.preventDefault()">Anterior</a>
+      </li>
+      <li class="page-item" *ngFor="let p of pages" [class.active]="p === currentPage">
+        <a class="page-link" href="#" (click)="goToPage(p); $event.preventDefault()">{{ p }}</a>
+      </li>
+      <li class="page-item" [class.disabled]="currentPage === totalPages">
+        <a class="page-link" href="#" (click)="goToPage(currentPage + 1); $event.preventDefault()">Siguiente</a>
+      </li>
+    </ul>
+  </nav>
   <p *ngIf="!accessories.length">No hay accesorios registrados.</p>
 </div>

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -39,6 +39,10 @@ export class AccesoriosComponent implements OnInit {
   accessories: Accessory[] = [];
   ownerId: number | null = null;
   activeTab: 'create' | 'list' = 'create';
+  listSearchText = '';
+  currentPage = 1;
+  pageSize = 10;
+  totalPages = 0;
 
   constructor(
     private materialService: MaterialService,
@@ -142,17 +146,51 @@ export class AccesoriosComponent implements OnInit {
   loadAccessories(): void {
     if (this.ownerId === null || isNaN(this.ownerId)) {
       this.accessories = [];
+      this.totalPages = 0;
       return;
     }
-    this.accessoryService.getAccessories(this.ownerId, 1, 10).subscribe({
-      next: res => {
-        const docs: any = (res as any).docs ?? (res as any).items ?? res;
-        this.accessories = Array.isArray(docs) ? docs : [];
-      },
-      error: () => {
-        this.accessories = [];
-      }
-    });
+    this.accessoryService
+      .getAccessories(
+        this.ownerId,
+        this.currentPage,
+        this.pageSize,
+        this.listSearchText
+      )
+      .subscribe({
+        next: res => {
+          const docs: any = (res as any).docs ?? (res as any).items ?? res;
+          this.accessories = Array.isArray(docs) ? docs : [];
+          let pages: any = (res as any).totalPages;
+          if (!Number.isFinite(pages)) {
+            const totalDocs = (res as any).totalDocs;
+            if (Number.isFinite(totalDocs) && this.pageSize > 0) {
+              pages = Math.ceil(totalDocs / this.pageSize);
+            }
+          }
+          this.totalPages = Number.isFinite(pages) ? pages : 0;
+        },
+        error: () => {
+          this.accessories = [];
+          this.totalPages = 0;
+        }
+      });
+  }
+
+  onListSearchChange(): void {
+    this.currentPage = 1;
+    this.loadAccessories();
+  }
+
+  get pages(): number[] {
+    return Array.from({ length: this.totalPages }, (_, i) => i + 1);
+  }
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages || page === this.currentPage) {
+      return;
+    }
+    this.currentPage = page;
+    this.loadAccessories();
   }
 
   getMaterialType(mat: Material): MaterialType | undefined {

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -77,7 +77,8 @@ export class AccessoryService {
   getAccessories(
     ownerId: number,
     page?: number,
-    limit?: number
+    limit?: number,
+    search?: string
   ): Observable<PaginatedAccessories> {
     let url = `${environment.apiUrl}/accessories?owner_id=${ownerId}`;
     const params: string[] = [];
@@ -86,6 +87,9 @@ export class AccessoryService {
     }
     if (limit !== undefined) {
       params.push(`limit=${limit}`);
+    }
+    if (search !== undefined && search !== '') {
+      params.push(`search=${encodeURIComponent(search)}`);
     }
     if (params.length) {
       url += `&${params.join('&')}`;


### PR DESCRIPTION
## Summary
- extend `AccessoryService.getAccessories` with search parameter
- support search and pagination in `AccesoriosComponent`
- add search field and page controls to accessories list view
- style pagination

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863145010e4832d8429136cbff190c5