### PR TITLE
Fix accessory list search

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -210,7 +210,7 @@
       (input)="onListSearchChange()"
     />
   </div>
-  <table *ngIf="accessories.length">
+  <table *ngIf="filteredAccessories.length">
     <thead>
       <tr>
         <th>ID</th>
@@ -222,7 +222,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let acc of accessories">
+      <tr *ngFor="let acc of filteredAccessories">
         <td>{{ acc.id }}</td>
         <td>{{ acc.name }}</td>
         <td>{{ acc.description }}</td>
@@ -245,5 +245,5 @@
       </li>
     </ul>
   </nav>
-  <p *ngIf="!accessories.length">No hay accesorios registrados.</p>
+  <p *ngIf="!filteredAccessories.length">No hay accesorios registrados.</p>
 </div>

--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -90,4 +90,17 @@ describe('AccesoriosComponent', () => {
 
     expect(cost).toBeCloseTo(600, 2);
   });
+
+  it('should filter accessories by search text', () => {
+    component.accessories = [
+      { id: 1, name: 'Alpha', description: 'Primero' } as any,
+      { id: 2, name: 'Beta', description: 'Segundo' } as any
+    ];
+    component.listSearchText = 'seg';
+
+    const filtered = component.filteredAccessories;
+
+    expect(filtered.length).toBe(1);
+    expect(filtered[0].id).toBe(2);
+  });
 });

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -176,6 +176,18 @@ export class AccesoriosComponent implements OnInit {
       });
   }
 
+  get filteredAccessories(): Accessory[] {
+    const term = this.listSearchText.trim().toLowerCase();
+    if (!term) {
+      return this.accessories;
+    }
+    return this.accessories.filter(acc =>
+      acc.id.toString().includes(term) ||
+      acc.name?.toLowerCase().includes(term) ||
+      acc.description?.toLowerCase().includes(term)
+    );
+  }
+
   onListSearchChange(): void {
     this.currentPage = 1;
     this.loadAccessories();


### PR DESCRIPTION
## Summary
- filter accessories on the client to make search functional
- update accessories list template to use filtered data
- extend unit tests for accessory component

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686317a5aa38832da1efc0b4a8e12dc5