### PR TITLE
Add edit button to accessories list

### DIFF
--- a/src/app/accesorios/accesorios.component.css
+++ b/src/app/accesorios/accesorios.component.css
@@ -38,6 +38,25 @@ th {
   font-size: 1.2rem;
 }
 
+.edit-btn {
+  background-color: #10a37f;
+  border: none;
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.edit-btn:hover {
+  background-color: #0e8a6e;
+}
+
+.edit-btn .material-icons {
+  font-size: 1.2rem;
+}
+
 .tabs {
   display: flex;
   border-bottom: 1px solid #565869;

--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -219,6 +219,7 @@
         <th>Costo total</th>
         <th>% Precio</th>
         <th>Precio total</th>
+        <th>Acciones</th>
       </tr>
     </thead>
     <tbody>
@@ -229,6 +230,16 @@
         <td>{{ acc.cost }}</td>
         <td>{{ calculatePricePercentage(acc) | number:'1.2-2' }}%</td>
         <td>{{ acc.price }}</td>
+        <td>
+          <button
+            type="button"
+            class="edit-btn"
+            title="Editar accesorio"
+            (click)="editAccessory(acc)"
+          >
+            <span class="material-icons" aria-hidden="true">edit</span>
+          </button>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -365,4 +365,8 @@ export class AccesoriosComponent implements OnInit {
         }
       });
   }
+
+  editAccessory(acc: Accessory): void {
+    // TODO: implement accessory editing
+  }
 }


### PR DESCRIPTION
## Summary
- show edit button in accessories list table
- add edit button styles
- stub `editAccessory` handler

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631a2d1e3c832d958118ad009e5630