### PR TITLE
Fix tab order for accessory editing

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -9,19 +9,19 @@
     Crear accesorio
   </button>
   <button
+    type="button"
+    [class.active]="activeTab === 'list'"
+    (click)="setTab('list')"
+  >
+    Listado de accesorios
+  </button>
+  <button
     *ngIf="isEditing"
     type="button"
     [class.active]="activeTab === 'edit'"
     (click)="setTab('edit')"
   >
     Editar accesorio
-  </button>
-  <button
-    type="button"
-    [class.active]="activeTab === 'list'"
-    (click)="setTab('list')"
-  >
-    Listado de accesorios
   </button>
 </div>
 


### PR DESCRIPTION
## Summary
- adjust the order of accessory tabs so the edit tab appears after the list tab

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632b25bc80832dbeeb3e17fb3e523e