### PR TITLE
Fix accessory form switch

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -152,10 +152,22 @@ export class AccesoriosComponent implements OnInit {
     this.closeRemoveModal();
   }
 
+  private resetForm(): void {
+    this.accessoryName = '';
+    this.accessoryDescription = '';
+    this.selected = [];
+    this.formSubmitted = false;
+    this.saveError = '';
+  }
+
   setTab(tab: 'create' | 'edit' | 'list'): void {
     this.activeTab = tab;
     if (tab === 'list' && this.ownerId !== null && !isNaN(this.ownerId)) {
       this.loadAccessories();
+    } else if (tab === 'create') {
+      this.isEditing = false;
+      this.editingId = null;
+      this.resetForm();
     }
   }
 


### PR DESCRIPTION
## Summary
- reset accessory form state when switching back to *Crear accesorio*

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: ng not found / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68632c522088832d8464f2239ad9ecf1