### PR TITLE
Load materials when editing accessory

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -209,6 +209,21 @@ export class AccesoriosComponent implements OnInit {
       next: acc => {
         this.accessoryName = acc.name;
         this.accessoryDescription = acc.description;
+        this.accessoryService.getAccessoryMaterials(id).subscribe({
+          next: mats => {
+            this.selected = Array.isArray(mats)
+              ? mats.map(m => ({
+                  material: (m as any).material ?? (m as any),
+                  width: m.width,
+                  length: m.length,
+                  quantity: m.quantity
+                }))
+              : [];
+          },
+          error: () => {
+            this.selected = [];
+          }
+        });
       },
       error: () => {
         // ignore errors

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -116,4 +116,9 @@ export class AccessoryService {
       this.httpOptions()
     );
   }
+
+  getAccessoryMaterials(id: number): Observable<AccessoryMaterial[]> {
+    const url = `${environment.apiUrl}/accessory-materials?accessory_id=${id}`;
+    return this.http.get<AccessoryMaterial[]>(url, this.httpOptions());
+  }
 }


### PR DESCRIPTION
## Summary
- add service call to list accessory materials
- load accessory's materials when editing an item

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632e1b86a8832db639e7b55ba1ce1e