### PR TITLE
Update accessory materials endpoint

### DIFF
--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -118,7 +118,7 @@ export class AccessoryService {
   }
 
   getAccessoryMaterials(id: number): Observable<AccessoryMaterial[]> {
-    const url = `${environment.apiUrl}/accessory-materials?accessory_id=${id}`;
+    const url = `${environment.apiUrl}/accessories/${id}/materials`;
     return this.http.get<AccessoryMaterial[]>(url, this.httpOptions());
   }
 }


### PR DESCRIPTION
## Summary
- use `/accessories/{id}/materials` endpoint when fetching materials for an accessory

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863320df738832d9ed7b5dd6fc6b807