### PR TITLE
Fix accessory material list

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -211,14 +211,17 @@ export class AccesoriosComponent implements OnInit {
         this.accessoryDescription = acc.description;
         this.accessoryService.getAccessoryMaterials(id).subscribe({
           next: mats => {
-            this.selected = Array.isArray(mats)
-              ? mats.map(m => ({
-                  material: (m as any).material ?? (m as any),
-                  width: m.width,
-                  length: m.length,
-                  quantity: m.quantity
-                }))
+            const materials: any[] = Array.isArray((mats as any).materials)
+              ? (mats as any).materials
+              : Array.isArray(mats)
+              ? (mats as any)
               : [];
+            this.selected = materials.map(m => ({
+              material: (m as any).material ?? (m as any),
+              width: m.width,
+              length: m.length,
+              quantity: m.quantity
+            }));
           },
           error: () => {
             this.selected = [];


### PR DESCRIPTION
## Summary
- handle accessory material endpoint returning an object with a `materials` array

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863332b1458832d93c2a86463c6f387