### PR TITLE
Fix area/quantity field visibility

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -269,12 +269,20 @@ export class AccesoriosComponent implements OnInit {
 
   isAreaType(mat: Material): boolean {
     const type = this.getMaterialType(mat);
-    return type?.id === 2;
+    if (!type) {
+      return false;
+    }
+    const ident = (type.unit || type.name || '').toLowerCase();
+    return type.id === 2 || ident.includes('m2') || ident.includes('área') || ident.includes('area');
   }
 
   isPieceType(mat: Material): boolean {
     const type = this.getMaterialType(mat);
-    return type?.id === 1;
+    if (!type) {
+      return false;
+    }
+    const ident = (type.unit || type.name || '').toLowerCase();
+    return type.id === 1 || ident.includes('pieza') || ident.includes('unidad');
   }
 
   isMaterialInfoValid(sel: SelectedMaterial): boolean {


### PR DESCRIPTION
## Summary
- ensure accessory materials show input fields even if type IDs vary

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863341e0b1c832d997060e12b34071f