### PR TITLE
Fix missing fields in accessory edit tab

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -121,7 +121,7 @@
           <td>{{ sel.material.name }}</td>
           <td>{{ sel.material.description }}</td>
           <td>
-            <ng-container *ngIf="isAreaType(sel.material); else otherType">
+            <ng-container *ngIf="isAreaType(sel.material) || sel.width !== undefined || sel.length !== undefined; else otherType">
               <input
                 type="number"
                 min="0"
@@ -142,7 +142,7 @@
               />
             </ng-container>
             <ng-template #otherType>
-              <ng-container *ngIf="isPieceType(sel.material); else typeName">
+              <ng-container *ngIf="isPieceType(sel.material) || sel.quantity !== undefined; else typeName">
                 <input
                   type="number"
                   min="0"


### PR DESCRIPTION
## Summary
- display width/length or quantity inputs if values are present

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686335b78954832d8e2bb962e6737a46