### PR TITLE
Fix accessory edit form type inputs

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -121,7 +121,7 @@
           <td>{{ sel.material.name }}</td>
           <td>{{ sel.material.description }}</td>
           <td>
-            <ng-container *ngIf="isAreaType(sel.material) || sel.width !== undefined || sel.length !== undefined; else otherType">
+            <ng-container *ngIf="isAreaType(sel.material) || (sel.width != null && sel.length != null); else otherType">
               <input
                 type="number"
                 min="0"
@@ -142,7 +142,7 @@
               />
             </ng-container>
             <ng-template #otherType>
-              <ng-container *ngIf="isPieceType(sel.material) || sel.quantity !== undefined; else typeName">
+              <ng-container *ngIf="isPieceType(sel.material) || sel.quantity != null; else typeName">
                 <input
                   type="number"
                   min="0"

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -269,6 +269,11 @@ export class AccesoriosComponent implements OnInit {
 
   isAreaType(mat: Material): boolean {
     const type = this.getMaterialType(mat);
+    // Avoid classifying piece based materials as area even if they have
+    // width/length metadata by explicitly checking the piece type first
+    if (this.isPieceType(mat)) {
+      return false;
+    }
     const ident = (type?.unit || type?.name || '').toLowerCase();
     return (
       (mat.width_m !== undefined && mat.length_m !== undefined) ||


### PR DESCRIPTION
## Summary
- ensure `isAreaType` doesn't misclassify piece materials
- only show length/width inputs when the material truly needs them

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633d7b5a8c832d82bea22ab8edfe4e