### PR TITLE
Update accessory editor material parsing

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -216,12 +216,24 @@ export class AccesoriosComponent implements OnInit {
               : Array.isArray(mats)
               ? (mats as any)
               : [];
-            this.selected = materials.map(m => ({
-              material: (m as any).material ?? (m as any),
-              width: m.width,
-              length: m.length,
-              quantity: m.quantity
-            }));
+            this.selected = materials.map(m => {
+              const mat: Material = (m as any).material ?? {
+                id: m.material_id ?? m.id,
+                name: m.material_name ?? m.name,
+                description: m.description,
+                material_type_id: m.material_type_id,
+                thickness_mm: m.thickness_mm,
+                width_m: m.width_m,
+                length_m: m.length_m,
+                price: m.price
+              };
+              return {
+                material: mat,
+                width: m.width ?? m.width_m_used,
+                length: m.length ?? m.length_m_used,
+                quantity: m.quantity
+              } as SelectedMaterial;
+            });
           },
           error: () => {
             this.selected = [];
@@ -268,6 +280,10 @@ export class AccesoriosComponent implements OnInit {
   }
 
   isAreaType(mat: Material): boolean {
+    const typeId = mat.material_type_id;
+    if (typeId != null) {
+      return typeId === 2;
+    }
     const type = this.getMaterialType(mat);
     // Avoid classifying piece based materials as area even if they have
     // width/length metadata by explicitly checking the piece type first
@@ -282,6 +298,10 @@ export class AccesoriosComponent implements OnInit {
   }
 
   isPieceType(mat: Material): boolean {
+    const typeId = mat.material_type_id;
+    if (typeId != null) {
+      return typeId === 1;
+    }
     const type = this.getMaterialType(mat);
     if (!type) {
       return false;

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { CookieService } from './cookie.service';
+import { Material } from './material.service';
 
 export interface Accessory {
   id: number;
@@ -20,8 +21,19 @@ export interface Accessory {
 export interface AccessoryMaterial {
   accessory_id: number;
   material_id: number;
+  /** Base material information when returned from the API */
+  material?: Material;
+  /** Material type identifier when returned from the API */
+  material_type_id?: number;
+  /**
+   * Values used when the material is measured by area.
+   * For backwards compatibility the API might also return `width`/`length`.
+   */
   width?: number;
   length?: number;
+  width_m_used?: number;
+  length_m_used?: number;
+  /** Quantity when the material is a discrete piece or other unit */
   quantity?: number;
   cost?: number;
   price?: number;


### PR DESCRIPTION
## Summary
- parse fields returned by accessories API when editing accessory
- extend AccessoryMaterial interface with info from API
- detect material type via `material_type_id`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863412bd730832d848f9f9fc1f5ba94