### PR TITLE
Add update accessory materials support

### DIFF
--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -21,6 +21,7 @@ describe('AccesoriosComponent', () => {
     accessoryServiceSpy = jasmine.createSpyObj('AccessoryService', [
       'addAccessory',
       'addAccessoryMaterials',
+      'updateAccessoryMaterials',
       'updateAccessory',
       'getAccessory'
     ]);

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -439,22 +439,23 @@ export class AccesoriosComponent implements OnInit {
             profit_percentage: this.profitPercentage
           };
         });
-        this.accessoryService
-          .addAccessoryMaterials(id, materials)
-          .subscribe({
-            next: () => {
-              this.isSaving = false;
-              if (!this.isEditing) {
-                this.accessoryName = '';
-                this.accessoryDescription = '';
-                this.selected = [];
-              }
-            },
-            error: () => {
-              this.isSaving = false;
-              this.saveError = 'Error al guardar materiales';
+        const materials$ = this.isEditing
+          ? this.accessoryService.updateAccessoryMaterials(id, materials)
+          : this.accessoryService.addAccessoryMaterials(id, materials);
+        materials$.subscribe({
+          next: () => {
+            this.isSaving = false;
+            if (!this.isEditing) {
+              this.accessoryName = '';
+              this.accessoryDescription = '';
+              this.selected = [];
             }
-          });
+          },
+          error: () => {
+            this.isSaving = false;
+            this.saveError = 'Error al guardar materiales';
+          }
+        });
       },
       error: () => {
         this.isSaving = false;

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -86,6 +86,18 @@ export class AccessoryService {
     );
   }
 
+  updateAccessoryMaterials(
+    accessoryId: number,
+    materials: AccessoryMaterial[]
+  ): Observable<any> {
+    const body = { accessory_id: accessoryId, materials };
+    return this.http.put<any>(
+      `${environment.apiUrl}/accessory-materials/${accessoryId}`,
+      body,
+      this.httpOptions()
+    );
+  }
+
   getAccessories(
     ownerId: number,
     page?: number,


### PR DESCRIPTION
## Summary
- support updating accessory materials in `AccessoryService`
- update `AccesoriosComponent` to call the new method when editing
- keep unit tests working by mocking the new service method

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686345fce238832d85ff6703fc0b13b7