### PR TITLE
Add accessory children management

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -87,6 +87,23 @@
       </li>
     </ul>
 
+      <div class="search-container">
+        <span class="material-icons">search</span>
+        <input
+          type="text"
+          placeholder="Buscar accesorios"
+          [(ngModel)]="childSearchText"
+          name="searchChild"
+          [ngModelOptions]="{ standalone: true }"
+          (input)="onAccessorySearchChange()"
+        />
+      </div>
+      <ul class="results" *ngIf="accessoryResults.length">
+        <li *ngFor="let a of accessoryResults" (click)="addChildAccessory(a)">
+          {{ a.name }}
+        </li>
+      </ul>
+
     <table class="summary-table">
       <tbody>
         <tr>
@@ -180,6 +197,40 @@
         </tr>
       </tbody>
     </table>
+
+    <table *ngIf="selectedChildren.length">
+      <thead>
+        <tr>
+          <th>Accesorio hijo</th>
+          <th>Cantidad</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let child of selectedChildren">
+          <td>{{ child.accessory.name }}</td>
+          <td>
+            <input
+              type="number"
+              min="1"
+              class="dim-input"
+              [(ngModel)]="child.quantity"
+              [ngModelOptions]="{ standalone: true }"
+            />
+          </td>
+          <td>
+            <button
+              type="button"
+              class="delete-btn"
+              title="Quitar"
+              (click)="openRemoveChildModal(child)"
+            >
+              <span class="material-icons" aria-hidden="true">delete</span>
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
   </div>
   <div class="error" *ngIf="saveError">{{ saveError }}</div>
@@ -205,6 +256,16 @@
       <button type="button" class="cancel-btn" (click)="closeRemoveModal()">Cancelar</button>
     </div>
   </div>
+</div>
+<div class="modal-overlay" *ngIf="showRemoveChildModal" (mousedown)="closeRemoveChildModal()">
+  <div class="confirm-modal" (mousedown)="$event.stopPropagation()" (click)="$event.stopPropagation()">
+    <span class="close-icon material-icons" (click)="closeRemoveChildModal()">close</span>
+    <p>¿Quitar accesorio?</p>
+    <div class="modal-actions">
+      <button type="button" (click)="confirmRemoveChild()">Quitar</button>
+      <button type="button" class="cancel-btn" (click)="closeRemoveChildModal()">Cancelar</button>
+</div>
+</div>
 </div>
 </div>
 

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -48,6 +48,14 @@ export interface PaginatedAccessories {
   totalPages: number;
 }
 
+export interface AccessoryComponent {
+  id: number;
+  parent_accessory_id: number;
+  child_accessory_id: number;
+  quantity: number;
+  child?: Accessory;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -144,5 +152,34 @@ export class AccessoryService {
   getAccessoryMaterials(id: number): Observable<AccessoryMaterial[]> {
     const url = `${environment.apiUrl}/accessories/${id}/materials`;
     return this.http.get<AccessoryMaterial[]>(url, this.httpOptions());
+  }
+
+  getAccessoryComponents(id: number): Observable<AccessoryComponent[]> {
+    const url = `${environment.apiUrl}/accessories/${id}/components`;
+    return this.http.get<AccessoryComponent[]>(url, this.httpOptions());
+  }
+
+  addAccessoryComponent(
+    parentId: number,
+    childId: number,
+    quantity: number
+  ): Observable<AccessoryComponent> {
+    const body = {
+      parent_accessory_id: parentId,
+      child_accessory_id: childId,
+      quantity
+    };
+    return this.http.post<AccessoryComponent>(
+      `${environment.apiUrl}/accessory-components`,
+      body,
+      this.httpOptions()
+    );
+  }
+
+  deleteAccessoryComponent(id: number): Observable<any> {
+    return this.http.delete<any>(
+      `${environment.apiUrl}/accessory-components/${id}`,
+      this.httpOptions()
+    );
   }
 }


### PR DESCRIPTION
## Summary
- implement `AccessoryComponent` API in `AccessoryService`
- allow selecting existing accessories as children when editing or creating
- show and remove child accessories in the accessories form

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68636c84ea3c832db1ba1557db085046