### PR TITLE
Add accessory cost/price totals

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -110,6 +110,14 @@
           <th>Total materiales</th>
           <td>{{ totalCost | number:'1.2-2' }}</td>
         </tr>
+        <tr *ngIf="selectedChildren.length">
+          <th>Total accesorios</th>
+          <td>{{ totalAccessoryCost | number:'1.2-2' }}</td>
+        </tr>
+        <tr *ngIf="selectedChildren.length">
+          <th>Precio accesorios</th>
+          <td>{{ totalAccessoryPrice | number:'1.2-2' }}</td>
+        </tr>
         <tr>
           <th>Porcentaje de ganancia</th>
           <td>{{ profitPercentage | number:'1.2-2' }}%</td>

--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -109,4 +109,20 @@ describe('AccesoriosComponent', () => {
     expect(filtered.length).toBe(1);
     expect(filtered[0].id).toBe(2);
   });
+
+  it('should sum accessory cost and price', () => {
+    component.selectedChildren = [
+      {
+        accessory: { id: 1, name: 'A', description: '', cost: 10, price: 15 } as any,
+        quantity: 2
+      },
+      {
+        accessory: { id: 2, name: 'B', description: '', cost: 5, price: 8 } as any,
+        quantity: 1
+      }
+    ] as any;
+
+    expect(component.totalAccessoryCost).toBe(25);
+    expect(component.totalAccessoryPrice).toBe(38);
+  });
 });

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -449,6 +449,22 @@ export class AccesoriosComponent implements OnInit {
     return this.totalCost * (1 + this.profitPercentage / 100);
   }
 
+  get totalAccessoryCost(): number {
+    return this.selectedChildren.reduce((sum, child) => {
+      const qty = child.quantity ?? 1;
+      const cost = child.accessory?.cost ?? 0;
+      return sum + cost * qty;
+    }, 0);
+  }
+
+  get totalAccessoryPrice(): number {
+    return this.selectedChildren.reduce((sum, child) => {
+      const qty = child.quantity ?? 1;
+      const price = child.accessory?.price ?? 0;
+      return sum + price * qty;
+    }, 0);
+  }
+
   calculatePricePercentage(acc: Accessory): number {
     if (!acc || acc.cost === undefined || acc.price === undefined) {
       return 0;


### PR DESCRIPTION
## Summary
- compute accessory cost and price totals
- show accessory totals in the accessory summary table
- test totals for accessories

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863703f76b4832da93c53465ea5c182