### PR TITLE
Add per-row accessory cost and price

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -211,6 +211,8 @@
         <tr>
           <th>Accesorio hijo</th>
           <th>Cantidad</th>
+          <th>Costo</th>
+          <th>Precio</th>
           <th></th>
         </tr>
       </thead>
@@ -226,6 +228,8 @@
               [ngModelOptions]="{ standalone: true }"
             />
           </td>
+          <td>{{ calculateChildCost(child) | number:'1.2-2' }}</td>
+          <td>{{ calculateChildPrice(child) | number:'1.2-2' }}</td>
           <td>
             <button
               type="button"

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -465,6 +465,18 @@ export class AccesoriosComponent implements OnInit {
     }, 0);
   }
 
+  calculateChildCost(child: SelectedAccessory): number {
+    const qty = child.quantity ?? 1;
+    const cost = child.accessory?.cost ?? 0;
+    return cost * qty;
+  }
+
+  calculateChildPrice(child: SelectedAccessory): number {
+    const qty = child.quantity ?? 1;
+    const price = child.accessory?.price ?? 0;
+    return price * qty;
+  }
+
   calculatePricePercentage(acc: Accessory): number {
     if (!acc || acc.cost === undefined || acc.price === undefined) {
       return 0;


### PR DESCRIPTION
## Summary
- show total cost and price for each child accessory row
- calculate child accessory totals in the component

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686371b3566c832dbdefd93683ea66bf