### PR TITLE
Add success message when saving accessories

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -246,6 +246,7 @@
   </div>
   </div>
   <div class="error" *ngIf="saveError">{{ saveError }}</div>
+  <div class="success" *ngIf="successMessage">{{ successMessage }}</div>
   <div class="form-actions">
     <button
       type="submit"

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -46,6 +46,7 @@ export class AccesoriosComponent implements OnInit {
   accessoryName = '';
   accessoryDescription = '';
   saveError = '';
+  successMessage = '';
   isSaving = false;
   formSubmitted = false;
   accessories: Accessory[] = [];
@@ -223,6 +224,7 @@ export class AccesoriosComponent implements OnInit {
     this.selectedChildren = [];
     this.formSubmitted = false;
     this.saveError = '';
+    this.successMessage = '';
   }
 
   setTab(tab: 'create' | 'edit' | 'list'): void {
@@ -573,12 +575,14 @@ export class AccesoriosComponent implements OnInit {
               let pending = newChildren.length;
               const finalizeSave = () => {
                 this.isSaving = false;
-                if (!this.isEditing) {
-                  this.accessoryName = '';
-                  this.accessoryDescription = '';
-                  this.selected = [];
-                  this.selectedChildren = [];
+                if (this.isEditing) {
+                  this.formSubmitted = false;
+                } else {
+                  this.resetForm();
                 }
+                this.saveError = '';
+                this.successMessage = 'Accesorio guardado exitosamente';
+                setTimeout(() => (this.successMessage = ''), 3000);
               };
               for (const child of newChildren) {
                 this.accessoryService
@@ -600,25 +604,27 @@ export class AccesoriosComponent implements OnInit {
             } else {
               const finalizeSave = () => {
                 this.isSaving = false;
-                if (!this.isEditing) {
-                  this.accessoryName = '';
-                  this.accessoryDescription = '';
-                  this.selected = [];
-                  this.selectedChildren = [];
+                if (this.isEditing) {
+                  this.formSubmitted = false;
+                } else {
+                  this.resetForm();
                 }
+                this.saveError = '';
+                this.successMessage = 'Accesorio guardado exitosamente';
+                setTimeout(() => (this.successMessage = ''), 3000);
               };
               finalizeSave();
             }
           },
-          error: () => {
+          error: err => {
             this.isSaving = false;
-            this.saveError = 'Error al guardar materiales';
+            this.saveError = err?.error?.message || 'Error al guardar materiales';
           }
         });
       },
-      error: () => {
+      error: err => {
         this.isSaving = false;
-        this.saveError = 'Error al guardar el accesorio';
+        this.saveError = err?.error?.message || 'Error al guardar el accesorio';
       }
     });
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -80,3 +80,9 @@ textarea {
   font-size: 0.8rem;
   margin-top: 0.25rem;
 }
+
+.success {
+  color: #4caf50;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- show a transient success message after accessory save
- show backend error messages on failure
- reset form flags after save

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646adc261c832d92a3f88d43087d8a