### PR TITLE
Fix form validations triggered after saving accessory

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -579,6 +579,7 @@ export class AccesoriosComponent implements OnInit {
                   this.formSubmitted = false;
                 } else {
                   this.resetForm();
+                  form.resetForm();
                 }
                 this.saveError = '';
                 this.successMessage = 'Accesorio guardado exitosamente';
@@ -608,6 +609,7 @@ export class AccesoriosComponent implements OnInit {
                   this.formSubmitted = false;
                 } else {
                   this.resetForm();
+                  form.resetForm();
                 }
                 this.saveError = '';
                 this.successMessage = 'Accesorio guardado exitosamente';


### PR DESCRIPTION
## Summary
- ensure accessory form resets its `ngForm` state on save success

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646c61424c832da8786c2fb4dcc0be