### PR TITLE
Fix child accessory info on edit

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -325,6 +325,18 @@ export class AccesoriosComponent implements OnInit {
                 component_id: c.id
               } as SelectedAccessory;
             });
+
+            // Fetch full accessory details to ensure name, cost and price are available
+            for (const sel of this.selectedChildren) {
+              this.accessoryService.getAccessory(sel.accessory.id).subscribe({
+                next: acc => {
+                  sel.accessory = { ...sel.accessory, ...acc };
+                },
+                error: () => {
+                  // ignore errors and keep existing partial data
+                }
+              });
+            }
           },
           error: () => {
             this.selectedChildren = [];


### PR DESCRIPTION
## Summary
- fetch child accessory details when editing accessories so name and pricing display correctly

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686474b9e700832da286b8153dd7284e