### PR TITLE
Fix accessory price calculation with flexible numbers

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -210,8 +210,8 @@ export class AccesoriosComponent implements OnInit {
               let cost = 0;
               let price = 0;
               for (const m of items) {
-                cost += Number(m.cost ?? 0);
-                price += Number(m.price ?? 0);
+                cost += this.toNumber(m.cost);
+                price += this.toNumber(m.price);
               }
               sel.accessory.cost = cost;
               sel.accessory.price = price;


### PR DESCRIPTION
## Summary
- ensure accessory totals parse localized number strings correctly

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647f7717c0832dae42dc82b43b1e9e