### PR TITLE
Fix accessory price parsing

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -210,8 +210,8 @@ export class AccesoriosComponent implements OnInit {
               let cost = 0;
               let price = 0;
               for (const m of items) {
-                cost += Number(m.cost ?? 0);
-                price += Number(m.price ?? 0);
+                cost += this.toNumber(m.cost);
+                price += this.toNumber(m.price);
               }
               sel.accessory.cost = cost;
               sel.accessory.price = price;
@@ -452,17 +452,21 @@ export class AccesoriosComponent implements OnInit {
       if (!trimmed) {
         return 0;
       }
-      const hasComma = trimmed.includes(',');
-      const hasDot = trimmed.includes('.');
-      let sanitized = trimmed;
-      if (hasComma && !hasDot) {
-        // treat comma as decimal separator when no dot is present
-        sanitized = sanitized.replace(',', '.');
+      // Remove spaces and currency symbols
+      const cleaned = trimmed.replace(/[^0-9.,-]/g, '').replace(/\s/g, '');
+      const lastComma = cleaned.lastIndexOf(',');
+      const lastDot = cleaned.lastIndexOf('.');
+      let normalized = cleaned;
+      if (lastComma > lastDot) {
+        // comma used as decimal separator -> remove dots as thousands
+        normalized = cleaned.replace(/\./g, '').replace(',', '.');
+      } else if (lastDot > lastComma) {
+        // dot used as decimal separator -> remove commas
+        normalized = cleaned.replace(/,/g, '');
       } else {
-        // otherwise assume commas are thousands separators
-        sanitized = sanitized.replace(/,/g, '');
+        normalized = cleaned.replace(/,/g, '');
       }
-      const n = parseFloat(sanitized);
+      const n = parseFloat(normalized);
       return Number.isFinite(n) ? n : 0;
     }
     return 0;


### PR DESCRIPTION
## Summary
- improve flexible number parsing utility to handle stray characters and identify decimal separator

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647f7717c0832dae42dc82b43b1e9e