### PR TITLE
Refactor toNumber parsing

### DIFF
--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -125,4 +125,14 @@ describe('AccesoriosComponent', () => {
     expect(component.totalAccessoryCost).toBe(25);
     expect(component.totalAccessoryPrice).toBe(38);
   });
+
+  it('should convert different numeric formats to numbers', () => {
+    const toNumber = (component as any).toNumber.bind(component);
+
+    expect(toNumber('1,234.56')).toBeCloseTo(1234.56, 2);
+    expect(toNumber('1.234,56')).toBeCloseTo(1234.56, 2);
+    expect(toNumber('$ 1 234,56')).toBeCloseTo(1234.56, 2);
+    expect(toNumber('')).toBe(0);
+    expect(toNumber('abc')).toBe(0);
+  });
 });

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -452,18 +452,16 @@ export class AccesoriosComponent implements OnInit {
       if (!trimmed) {
         return 0;
       }
-      // Remove spaces and currency symbols
-      const cleaned = trimmed.replace(/[^0-9.,-]/g, '').replace(/\s/g, '');
+      // Remove currency symbols and other non-numeric characters
+      const cleaned = trimmed.replace(/[^0-9.,-]/g, '');
       const lastComma = cleaned.lastIndexOf(',');
       const lastDot = cleaned.lastIndexOf('.');
       let normalized = cleaned;
       if (lastComma > lastDot) {
-        // comma used as decimal separator -> remove dots as thousands
+        // comma used as decimal separator -> remove dots used as thousands
         normalized = cleaned.replace(/\./g, '').replace(',', '.');
-      } else if (lastDot > lastComma) {
-        // dot used as decimal separator -> remove commas
-        normalized = cleaned.replace(/,/g, '');
       } else {
+        // dot used as decimal separator -> remove commas
         normalized = cleaned.replace(/,/g, '');
       }
       const n = parseFloat(normalized);


### PR DESCRIPTION
## Summary
- clean up number parsing in accesorios component
- test different numeric formats

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648544bd8c832d9f2393d9998dd760