### PR TITLE
Fix accessory child totals

### DIFF
--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -126,6 +126,18 @@ describe('AccesoriosComponent', () => {
     expect(component.totalAccessoryPrice).toBe(38);
   });
 
+  it('should not fetch totals when accessory already has cost and price', () => {
+    const acc: any = { id: 3, name: 'C', cost: 7, price: 9 };
+    spyOn<any>(component, 'populateAccessoryTotals');
+
+    component.addChildAccessory(acc);
+
+    expect((component as any).populateAccessoryTotals).not.toHaveBeenCalled();
+    expect(component.selectedChildren.length).toBe(1);
+    expect(component.selectedChildren[0].accessory.cost).toBe(7);
+    expect(component.selectedChildren[0].accessory.price).toBe(9);
+  });
+
   it('should convert different numeric formats to numbers', () => {
     const toNumber = (component as any).toNumber.bind(component);
 

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -171,8 +171,11 @@ export class AccesoriosComponent implements OnInit {
       this.childSearchText = '';
       this.accessoryResults = [];
 
-      // Fetch full accessory details to populate cost and price
-      this.populateAccessoryTotals(sel);
+      // Fetch full accessory details to populate cost and price only when
+      // the selected accessory lacks this information.
+      if (acc.cost === undefined || acc.price === undefined) {
+        this.populateAccessoryTotals(sel);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid refetching accessory totals if cost and price already exist
- add test for skipping populateAccessoryTotals

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_686488f876dc832dbaddfc4a1e01a54a