### PR TITLE
Handle accessory component totals correctly

### DIFF
--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -7,6 +7,7 @@ import { MaterialService } from '../services/material.service';
 import { MaterialTypeService } from '../services/material-type.service';
 import { CookieService } from '../services/cookie.service';
 import { AccessoryService } from '../services/accessory.service';
+import { of } from 'rxjs';
 
 describe('AccesoriosComponent', () => {
   let component: AccesoriosComponent;
@@ -23,7 +24,9 @@ describe('AccesoriosComponent', () => {
       'addAccessoryMaterials',
       'updateAccessoryMaterials',
       'updateAccessory',
-      'getAccessory'
+      'getAccessory',
+      'getAccessoryMaterials',
+      'getAccessoryComponents'
     ]);
     TestBed.configureTestingModule({
       declarations: [AccesoriosComponent],
@@ -136,6 +139,40 @@ describe('AccesoriosComponent', () => {
     expect(component.selectedChildren.length).toBe(1);
     expect(component.selectedChildren[0].accessory.cost).toBe(7);
     expect(component.selectedChildren[0].accessory.price).toBe(9);
+  });
+
+  it('should load component cost and price from API response', () => {
+    (accessoryServiceSpy.getAccessory as jasmine.Spy).and.returnValue(of({
+      id: 10,
+      name: 'Parent',
+      description: 'P'
+    } as any));
+    (accessoryServiceSpy.getAccessoryMaterials as jasmine.Spy).and.returnValue(
+      of([])
+    );
+    (accessoryServiceSpy.getAccessoryComponents as jasmine.Spy).and.returnValue(
+      of([
+        {
+          id: 1,
+          parent_accessory_id: 10,
+          child_accessory_id: 2,
+          quantity: 5,
+          cost: 7.57,
+          price: 10.6,
+          child: { id: 2, name: 'Child', description: '' }
+        }
+      ])
+    );
+
+    spyOn<any>(component, 'populateAccessoryTotals');
+
+    (component as any).loadAccessory(10);
+
+    expect(component.selectedChildren.length).toBe(1);
+    const child = component.selectedChildren[0];
+    expect(child.accessory.cost).toBe(7.57);
+    expect(child.accessory.price).toBe(10.6);
+    expect((component as any).populateAccessoryTotals).not.toHaveBeenCalled();
   });
 
   it('should convert different numeric formats to numbers', () => {

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -355,10 +355,15 @@ export class AccesoriosComponent implements OnInit {
               ? (comps as any)
               : [];
             this.selectedChildren = items.map(c => {
-              const child: Accessory = (c as any).child ?? {
+              const base: Accessory = (c as any).child ?? {
                 id: c.child_accessory_id,
                 name: (c as any).child_name ?? '',
                 description: (c as any).child_description ?? ''
+              };
+              const child: Accessory = {
+                ...base,
+                cost: c.cost,
+                price: c.price
               };
               return {
                 accessory: child,
@@ -369,7 +374,12 @@ export class AccesoriosComponent implements OnInit {
 
             // Fetch full accessory details to ensure name, cost and price are available
             for (const sel of this.selectedChildren) {
-              this.populateAccessoryTotals(sel);
+              if (
+                sel.accessory.cost === undefined ||
+                sel.accessory.price === undefined
+              ) {
+                this.populateAccessoryTotals(sel);
+              }
             }
           },
           error: () => {

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -53,6 +53,10 @@ export interface AccessoryComponent {
   parent_accessory_id: number;
   child_accessory_id: number;
   quantity: number;
+  /** Cost for the specified quantity */
+  cost?: number;
+  /** Price for the specified quantity */
+  price?: number;
   child?: Accessory;
 }
 


### PR DESCRIPTION
## Summary
- include cost and price fields in `AccessoryComponent`
- use component-provided cost and price when loading children
- test that component cost/price from API are respected

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_68648bb52fb8832dba99da3441dddbb6