### PR TITLE
Fix accessory profit totals

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -114,6 +114,10 @@
           <th>Total accesorios</th>
           <td>{{ totalAccessoryCost | number:'1.2-2' }}</td>
         </tr>
+        <tr>
+          <th>Precio materiales</th>
+          <td>{{ totalMaterialPrice | number:'1.2-2' }}</td>
+        </tr>
         <tr *ngIf="selectedChildren.length">
           <th>Precio accesorios</th>
           <td>{{ totalAccessoryPrice | number:'1.2-2' }}</td>

--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -129,6 +129,25 @@ describe('AccesoriosComponent', () => {
     expect(component.totalAccessoryPrice).toBe(38);
   });
 
+  it('should compute material price and total with profit', () => {
+    component.profitPercentage = 40;
+    component.selected = [
+      {
+        material: { id: 1, name: 'Mat', material_type_id: 1, price: 10 } as any,
+        quantity: 2
+      }
+    ] as any;
+    component.selectedChildren = [
+      {
+        accessory: { id: 3, name: 'Child', cost: 5, price: 7 } as any,
+        quantity: 3
+      }
+    ] as any;
+
+    expect(component.totalMaterialPrice).toBeCloseTo(28, 2);
+    expect(component.totalWithProfit).toBeCloseTo(49, 2);
+  });
+
   it('should not fetch totals when accessory already has cost and price', () => {
     const acc: any = { id: 3, name: 'C', cost: 7, price: 9 };
     spyOn<any>(component, 'populateAccessoryTotals');

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -530,8 +530,12 @@ export class AccesoriosComponent implements OnInit {
     return this.selected.reduce((sum, sel) => sum + this.calculateCost(sel), 0);
   }
 
-  get totalWithProfit(): number {
+  get totalMaterialPrice(): number {
     return this.totalCost * (1 + this.profitPercentage / 100);
+  }
+
+  get totalWithProfit(): number {
+    return this.totalMaterialPrice + this.totalAccessoryPrice;
   }
 
   get totalAccessoryCost(): number {


### PR DESCRIPTION
## Summary
- add `totalMaterialPrice` getter
- compute `totalWithProfit` using material and accessory prices
- show materials price in the accessory summary table
- test total profit calculation

## Testing
- `npm test` *(fails: 403 Forbidden when accessing registry)*

------
https://chatgpt.com/codex/tasks/task_e_68648ec53024832daef2484e667a7a48