### PR TITLE
Handle accessory totals server-side

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -640,16 +640,12 @@ export class AccesoriosComponent implements OnInit {
       next: (acc: Accessory) => {
         const id = this.isEditing && this.editingId !== null ? this.editingId : acc.id;
         const materials: AccessoryMaterial[] = this.selected.map(sel => {
-          const cost = this.calculateCost(sel);
           return {
             accessory_id: id,
             material_id: sel.material.id,
             width: sel.width,
             length: sel.length,
-            quantity: sel.quantity,
-            cost,
-            price: cost * (1 + this.profitPercentage / 100),
-            profit_percentage: this.profitPercentage
+            quantity: sel.quantity
           };
         });
         const materials$ = this.isEditing


### PR DESCRIPTION
## Summary
- stop including cost and price when sending accessory materials

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_686555c3ea5c832d9c466d0798691749