### PR TITLE
Add accessory cost endpoint usage

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -130,6 +130,14 @@
           <th>Total + ganancia</th>
           <td>{{ totalWithProfit | number:'1.2-2' }}</td>
         </tr>
+        <tr *ngIf="apiCost != null">
+          <th>Costo actualizado</th>
+          <td>{{ apiCost | number:'1.2-2' }}</td>
+        </tr>
+        <tr *ngIf="apiPrice != null">
+          <th>Precio actualizado</th>
+          <td>{{ apiPrice | number:'1.2-2' }}</td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -26,7 +26,8 @@ describe('AccesoriosComponent', () => {
       'updateAccessory',
       'getAccessory',
       'getAccessoryMaterials',
-      'getAccessoryComponents'
+      'getAccessoryComponents',
+      'getAccessoryCost'
     ]);
     TestBed.configureTestingModule({
       declarations: [AccesoriosComponent],
@@ -181,6 +182,16 @@ describe('AccesoriosComponent', () => {
           child: { id: 2, name: 'Child', description: '' }
         }
       ])
+    );
+    (accessoryServiceSpy.getAccessoryCost as jasmine.Spy).and.returnValue(
+      of({
+        accessory_id: 10,
+        accessory_name: 'Parent',
+        cost: 0,
+        price: 0,
+        profit_margin: 0,
+        profit_percentage: 0
+      })
     );
 
     spyOn<any>(component, 'populateAccessoryTotals');

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -60,6 +60,15 @@ export interface AccessoryComponent {
   child?: Accessory;
 }
 
+export interface AccessoryTotals {
+  accessory_id: number;
+  accessory_name: string;
+  cost: number;
+  price: number;
+  profit_margin: number;
+  profit_percentage: number;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -185,5 +194,13 @@ export class AccessoryService {
       `${environment.apiUrl}/accessory-components/${id}`,
       this.httpOptions()
     );
+  }
+
+  getAccessoryCost(id: number, ownerId?: number): Observable<AccessoryTotals> {
+    let url = `${environment.apiUrl}/accessories/${id}/cost`;
+    if (ownerId !== undefined) {
+      url += `?owner_id=${ownerId}`;
+    }
+    return this.http.get<AccessoryTotals>(url, this.httpOptions());
   }
 }


### PR DESCRIPTION
## Summary
- define `AccessoryTotals` interface and `getAccessoryCost()` in `AccessoryService`
- store and display API-calculated totals in `AccesoriosComponent`
- refresh totals when loading/editing accessories
- update unit tests for new service method

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_686578ef6844832d91130195a68957dc