### PR TITLE
Fix totals table for accessories

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -157,18 +157,35 @@
         <tr class="desc-row">
           <td colspan="2">Resultado de sumar el costo total con la ganancia.</td>
         </tr>
-        <tr *ngIf="apiCost != null || apiPrice != null" class="section-header">
+        <tr class="section-header">
           <th colspan="2">Valores calculados</th>
         </tr>
-        <tr *ngIf="apiCost != null">
+        <tr>
           <th>Costo actualizado</th>
+          <td>{{ combinedCost | number:'1.2-2' }}</td>
+        </tr>
+        <tr class="desc-row">
+          <td colspan="2">Costo total sumando materiales y accesorios.</td>
+        </tr>
+        <tr>
+          <th>Precio actualizado</th>
+          <td>{{ totalWithProfit | number:'1.2-2' }}</td>
+        </tr>
+        <tr class="desc-row">
+          <td colspan="2">Precio final registrado tras aplicar la ganancia.</td>
+        </tr>
+        <tr *ngIf="apiCost != null || apiPrice != null" class="section-header">
+          <th colspan="2">Valores guardados</th>
+        </tr>
+        <tr *ngIf="apiCost != null">
+          <th>Costo guardado</th>
           <td>{{ apiCost | number:'1.2-2' }}</td>
         </tr>
         <tr *ngIf="apiCost != null" class="desc-row">
           <td colspan="2">Costo guardado en el servidor.</td>
         </tr>
         <tr *ngIf="apiPrice != null">
-          <th>Precio actualizado</th>
+          <th>Precio guardado</th>
           <td>{{ apiPrice | number:'1.2-2' }}</td>
         </tr>
         <tr *ngIf="apiPrice != null" class="desc-row">

--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -147,6 +147,8 @@ describe('AccesoriosComponent', () => {
 
     expect(component.totalMaterialPrice).toBeCloseTo(28, 2);
     expect(component.totalWithProfit).toBeCloseTo(49, 2);
+    expect(component.combinedCost).toBeCloseTo(35, 2);
+    expect(component.combinedPrice).toBeCloseTo(49, 2);
   });
 
   it('should not fetch totals when accessory already has cost and price', () => {

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -569,6 +569,14 @@ export class AccesoriosComponent implements OnInit {
     }, 0);
   }
 
+  get combinedCost(): number {
+    return this.totalCost + this.totalAccessoryCost;
+  }
+
+  get combinedPrice(): number {
+    return this.totalWithProfit;
+  }
+
   calculateChildCost(child: SelectedAccessory): number {
     const qty = toNumber(child.quantity ?? 1);
     const cost = toNumber(child.accessory?.cost);


### PR DESCRIPTION
## Summary
- compute accessory total cost and price on the client
- display calculated and stored values separately
- test combined cost and price calculations

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_68659c71bbf0832db2a981cad2195ab6