### PR TITLE
Remove saved totals from accessory form

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -174,23 +174,6 @@
         <tr class="desc-row">
           <td colspan="2">Precio final registrado tras aplicar la ganancia.</td>
         </tr>
-        <tr *ngIf="apiCost != null || apiPrice != null" class="section-header">
-          <th colspan="2">Valores guardados</th>
-        </tr>
-        <tr *ngIf="apiCost != null">
-          <th>Costo guardado</th>
-          <td>{{ apiCost | number:'1.2-2' }}</td>
-        </tr>
-        <tr *ngIf="apiCost != null" class="desc-row">
-          <td colspan="2">Costo guardado en el servidor.</td>
-        </tr>
-        <tr *ngIf="apiPrice != null">
-          <th>Precio guardado</th>
-          <td>{{ apiPrice | number:'1.2-2' }}</td>
-        </tr>
-        <tr *ngIf="apiPrice != null" class="desc-row">
-          <td colspan="2">Precio final registrado tras aplicar la ganancia.</td>
-        </tr>
       </tbody>
     </table>
   </div>

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -56,8 +56,6 @@ export class AccesoriosComponent implements OnInit {
   ownerId: number | null = null;
   isEditing = false;
   editingId: number | null = null;
-  apiCost: number | null = null;
-  apiPrice: number | null = null;
   activeTab: 'create' | 'edit' | 'list' = 'create';
   listSearchText = '';
   currentPage = 1;
@@ -279,8 +277,6 @@ export class AccesoriosComponent implements OnInit {
     this.formSubmitted = false;
     this.saveError = '';
     this.successMessage = '';
-    this.apiCost = null;
-    this.apiPrice = null;
   }
 
   setTab(tab: 'create' | 'edit' | 'list'): void {
@@ -604,8 +600,6 @@ export class AccesoriosComponent implements OnInit {
     }
     this.accessoryService.getAccessoryCost(id, this.ownerId).subscribe({
       next: (res) => {
-        this.apiCost = res.cost;
-        this.apiPrice = res.price;
         if (typeof res.profit_percentage === 'number') {
           this.profitPercentage = res.profit_percentage;
         }


### PR DESCRIPTION
## Summary
- drop saved totals from accessory view
- remove unused `apiCost` and `apiPrice` fields

## Testing
- `npm test --silent --yes` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68659e020160832da75eb31761734e81