### PR TITLE
Add materials to accessory creation

### DIFF
--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -40,6 +40,11 @@ export interface AccessoryMaterial {
   profit_percentage?: number;
 }
 
+export interface AccessoryMaterialPayload
+  extends Omit<AccessoryMaterial, 'accessory_id'> {
+  accessory_id?: number;
+}
+
 export interface PaginatedAccessories {
   docs: Accessory[];
   totalDocs: number;
@@ -92,9 +97,17 @@ export class AccessoryService {
   addAccessory(
     name: string,
     description: string,
-    ownerId: number
+    ownerId: number,
+    materials: AccessoryMaterialPayload[] = [],
+    accessories: AccessoryChildPayload[] = []
   ): Observable<Accessory> {
-    const body = { name, description, owner_id: ownerId };
+    const body: any = { name, description, owner_id: ownerId };
+    if (materials.length) {
+      body.materials = materials;
+    }
+    if (accessories.length) {
+      body.accessories = accessories;
+    }
     return this.http.post<Accessory>(
       `${environment.apiUrl}/accessories`,
       body,


### PR DESCRIPTION
## Summary
- allow passing materials and child accessories when creating an accessory
- send materials and accessories in `AccesoriosComponent` when saving new accessories

## Testing
- `npm test` *(fails: 403 Forbidden when trying to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865a7385124832d994c289610486d52