### PR TITLE
Fix type mismatch for updateAccessoryMaterials

### DIFF
--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -143,7 +143,7 @@ export class AccessoryService {
   updateAccessoryMaterials(
     accessoryId: number,
     markupPercentage: number,
-    materials: AccessoryMaterial[],
+    materials: AccessoryMaterialPayload[],
     accessories: AccessoryChildPayload[] = [],
     totalMaterialsPrice?: number,
     totalAccessoriesPrice?: number,


### PR DESCRIPTION
## Summary
- allow `updateAccessoryMaterials` to accept `AccessoryMaterialPayload[]`

## Testing
- `npm test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6865ada12b2c832db2688a2664753613