### PR TITLE
Fix accessory edit form material field visibility

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -194,7 +194,7 @@
           <td>{{ sel.material.name }}</td>
           <td>{{ sel.material.description }}</td>
           <td>
-            <ng-container *ngIf="isAreaType(sel.material) || (sel.width != null && sel.length != null); else otherType">
+            <ng-container *ngIf="isAreaSel(sel); else otherType">
               <input
                 type="number"
                 min="0"
@@ -215,12 +215,12 @@
               />
             </ng-container>
             <ng-template #otherType>
-              <ng-container *ngIf="isPieceType(sel.material) || sel.quantity != null; else typeName">
+              <ng-container *ngIf="isPieceSel(sel); else typeName">
                 <input
                   type="number"
                   min="0"
-                class="dim-input"
-                [(ngModel)]="sel.quantity"
+                  class="dim-input"
+                  [(ngModel)]="sel.quantity"
                 [ngModelOptions]="{ standalone: true, updateOn: 'change' }"
                 placeholder="Piezas"
                 (input)="onMaterialInput(sel)"
@@ -232,7 +232,7 @@
             </ng-template>
             <div class="error" *ngIf="formSubmitted && sel._invalid">
               Completa {{
-                isAreaType(sel.material)
+                isAreaSel(sel)
                   ? 'largo y ancho'
                   : 'la cantidad'
               }}

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -25,6 +25,8 @@ export interface AccessoryMaterial {
   material?: Material;
   /** Material type identifier when returned from the API */
   material_type_id?: number;
+  /** Unit of measure for the material when returned from the API */
+  unit?: string;
   /**
    * Values used when the material is measured by area.
    * For backwards compatibility the API might also return `width`/`length`.


### PR DESCRIPTION
## Summary
- track the material unit when loading accessory materials
- evaluate `unit` to display width/length or quantity fields
- add helper methods `isAreaSel` and `isPieceSel` to centralize logic

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_6865c1fc7c38832da9a871e47369ce16