### PR TITLE
Fix accessory edit cost rendering

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -238,8 +238,8 @@
               }}
             </div>
           </td>
-          <td>{{ calculateCost(sel) | number:'1.2-2' }}</td>
-          <td>{{ sel.material.price }}</td>
+          <td>{{ sel.cost | number:'1.2-2' }}</td>
+          <td>{{ sel.investment | number:'1.2-2' }}</td>
           <td>
             <button
               type="button"

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -30,6 +30,10 @@ interface SelectedMaterial {
   /** Unit of measure used when editing an existing accessory */
   unit?: string;
   quantity?: number;
+  /** Stored cost for this material selection */
+  cost?: number;
+  /** Base investment of the material */
+  investment?: number;
   _invalid?: boolean;
 }
 
@@ -166,7 +170,7 @@ export class AccesoriosComponent implements OnInit {
 
   addMaterial(mat: Material): void {
     if (!this.selected.some((m) => m.material.id === mat.id)) {
-      this.selected.push({ material: mat });
+      this.selected.push({ material: mat, investment: mat.price, cost: undefined });
       this.searchText = '';
       this.results = [];
     }
@@ -343,6 +347,10 @@ export class AccesoriosComponent implements OnInit {
                 ? (mats as any)
                 : [];
             this.selected = materials.map((m) => {
+              const basePrice =
+                (m as any).investment ??
+                (m as any).material?.price ??
+                m.price;
               const mat: Material = (m as any).material ?? {
                 id: m.material_id ?? m.id,
                 name: m.material_name ?? m.name,
@@ -351,7 +359,7 @@ export class AccesoriosComponent implements OnInit {
                 thickness_mm: m.thickness_mm,
                 width_m: m.width_m,
                 length_m: m.length_m,
-                price: m.price,
+                price: basePrice,
               };
               return {
                 material: mat,
@@ -359,6 +367,8 @@ export class AccesoriosComponent implements OnInit {
                 length: m.length ?? m.length_m_used,
                 unit: m.unit,
                 quantity: m.quantity,
+                cost: m.cost,
+                investment: basePrice,
               } as SelectedMaterial;
             });
           },
@@ -543,6 +553,7 @@ export class AccesoriosComponent implements OnInit {
     if (sel._invalid && this.isMaterialInfoValid(sel)) {
       sel._invalid = false;
     }
+    sel.cost = this.calculateCost(sel);
   }
 
   calculateCost(sel: SelectedMaterial): number {
@@ -738,7 +749,7 @@ export class AccesoriosComponent implements OnInit {
         quantity: toNumber(sel.quantity),
         cost,
         price,
-        investment: toNumber(sel.material.price),
+        investment: toNumber(sel.investment ?? sel.material.price),
         description: sel.material.description,
       } as AccessoryMaterialDetail;
     });


### PR DESCRIPTION
## Summary
- store existing cost and investment when loading accessory materials
- show stored cost and investment in the edit table

## Testing
- `npm test --silent` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_6865cae3aac0832d9d83d4f7d69de4f1