### PR TITLE
Fix accessory edit totals

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -274,6 +274,7 @@
               class="dim-input"
               [(ngModel)]="child.quantity"
               [ngModelOptions]="{ standalone: true, updateOn: 'change' }"
+              (input)="onChildInput()"
             />
           </td>
           <td>{{ calculateChildCost(child) | number:'1.2-2' }}</td>

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -13,6 +13,20 @@ export interface Accessory {
   cost?: number;
   /** Final price including profit percentage */
   price?: number;
+  /** Stored markup percentage */
+  markup_percentage?: number;
+  /** Total cost of all materials */
+  total_materials_cost?: number;
+  /** Total price of all materials */
+  total_materials_price?: number;
+  /** Total cost of all child accessories */
+  total_accessories_cost?: number;
+  /** Total price of all child accessories */
+  total_accessories_price?: number;
+  /** Combined materials and accessories cost */
+  total_cost?: number;
+  /** Final price including profit */
+  total_price?: number;
   owner_id?: number;
   created_at?: string;
   updated_at?: string;


### PR DESCRIPTION
## Summary
- include total fields on `Accessory` model
- track totals returned from API and only recalc when the user changes values
- update totals after saving
- trigger recalculation when editing child quantity

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm run build` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d246de94832d8063eb584b347481