### PR TITLE
Fix accessory totals on edit load

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -418,26 +418,6 @@ export class AccesoriosComponent implements OnInit {
               } as SelectedMaterial;
             });
 
-            // Recalculate costs for area-based materials when not provided
-            for (const sel of this.selected) {
-              if (this.isAreaSel(sel) && (!sel.cost || sel.cost === 0)) {
-                sel.cost = this.calculateCost(sel);
-              }
-            }
-
-            // If API totals were missing, derive them from the loaded materials
-            const calcTotal = this.selected.reduce(
-              (sum, sel) => sum + this.toNumber(sel.cost),
-              0,
-            );
-            if (!this.apiTotals.total_materials_cost) {
-              this.apiTotals.total_materials_cost = calcTotal;
-            }
-            if (!this.apiTotals.total_materials_price) {
-              this.apiTotals.total_materials_price =
-                calcTotal * (1 + this.profitPercentage / 100);
-            }
-
             this.initializingMaterials = false;
           },
           error: () => {


### PR DESCRIPTION
## Summary
- avoid recalculating accessory totals when loading an accessory for edit

## Testing
- `npm test` *(fails: 403 Forbidden due to network access)*
- `npx ng build` *(fails: 403 Forbidden due to network access)*

------
https://chatgpt.com/codex/tasks/task_e_6865d7e57de0832d8d747e1d2f04e9c9