### PR TITLE
Avoid quantity in area material payload

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -847,17 +847,22 @@ export class AccesoriosComponent implements OnInit {
           : this.calculateCost(sel);
       const price = cost + (markup / 100) * cost;
       const unit = this.isAreaSel(sel) ? 'm²' : 'unit';
-      return {
+      const detail: AccessoryMaterialDetail = {
         material_id: sel.material.id,
         width: toNumber(sel.width),
         length: toNumber(sel.length),
         unit,
-        quantity: toNumber(sel.quantity),
         cost,
         price,
         investment: toNumber(sel.investment ?? sel.material.price),
         description: sel.material.description,
-      } as AccessoryMaterialDetail;
+      };
+
+      if (unit !== 'm²') {
+        detail.quantity = toNumber(sel.quantity);
+      }
+
+      return detail;
     });
     const accessoriesDetailed: AccessoryChildDetail[] = this.selectedChildren.map((child) => {
       return {


### PR DESCRIPTION
## Summary
- update accessory material mapping to omit `quantity` when the unit is `m²`

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_6865dd66dfe0832db2cc247662055fa4