### PR TITLE
Adjust update accessory payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ updating accessories and their materials/components:
 - `POST /accessories` Crea un accesorio y puede incluir los campos `materials`
   y `accessories` para vincularlos en la misma solicitud. La respuesta devuelve
   los totales de costo y precio calculados.
-- `PUT /accessories/:id`
+- `PUT /accessories/:id` Actualiza un accesorio existente. Solo envía los
+  campos básicos (`name`, `description`, `markup_percentage`, `owner_id`,
+  `materials` y `accessories`). Los totales de costo y precio se recalculan en
+  el servidor y **no** deben incluirse en el payload.
 - `POST /accessory-materials` Vincula materiales a un accesorio de forma
   independiente. Cuando se envían `cost` o `price` se multiplican por
   `quantity` para guardar el total.

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -896,11 +896,6 @@ export class AccesoriosComponent implements OnInit {
       markup_percentage: markup,
       materials: materialsDetailed,
       accessories: accessoriesDetailed,
-      totals: {
-        total_materials_cost: this.totalCost,
-        total_accessories_cost: this.totalAccessoryCost,
-        total_cost: this.combinedCost,
-      },
     } as AccessoryUpdatePayload;
 
     const save$ =
@@ -925,12 +920,12 @@ export class AccesoriosComponent implements OnInit {
           setTimeout(() => (this.successMessage = ''), 3000);
           this.updateApiTotals(id);
           this.apiTotals = {
-            total_materials_cost: this.totalCost,
-            total_materials_price: this.totalMaterialPrice,
-            total_accessories_cost: this.totalAccessoryCost,
-            total_accessories_price: this.totalAccessoryPrice,
-            total_cost: this.combinedCost,
-            total_price: this.combinedPrice,
+            total_materials_cost: this.toNumber((acc as any).total_materials_cost),
+            total_materials_price: this.toNumber((acc as any).total_materials_price),
+            total_accessories_cost: this.toNumber((acc as any).total_accessories_cost),
+            total_accessories_price: this.toNumber((acc as any).total_accessories_price),
+            total_cost: this.toNumber((acc as any).total_cost),
+            total_price: this.toNumber((acc as any).total_price),
           };
           this.totalsDirty = false;
         };

--- a/src/app/services/accessory.service.ts
+++ b/src/app/services/accessory.service.ts
@@ -130,11 +130,6 @@ export interface AccessoryUpdatePayload {
   markup_percentage: number;
   materials: AccessoryMaterialDetail[];
   accessories: AccessoryChildDetail[];
-  totals: {
-    total_materials_cost: number;
-    total_accessories_cost: number;
-    total_cost: number;
-  };
 }
 
 export interface AccessoryTotals {


### PR DESCRIPTION
## Summary
- document how to update accessories without totals
- update accessory update payload definition
- avoid sending totals when editing accessories
- rely on server response for updated totals

## Testing
- `npm test` *(fails: 403 Forbidden trying to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865e4771590832d9d70432e84510160