### PR TITLE
Fix area cost recalculation

### DIFF
--- a/src/app/accesorios/accesorios.component.spec.ts
+++ b/src/app/accesorios/accesorios.component.spec.ts
@@ -102,6 +102,28 @@ describe('AccesoriosComponent', () => {
     expect(cost).toBeCloseTo(600, 2);
   });
 
+  it('should compute area cost using base dimensions when unit is m²', () => {
+    const mat = {
+      id: 3,
+      name: 'MDF',
+      description: 'Board',
+      material_type_id: 2,
+      price: 1000,
+      width_m: 1.22,
+      length_m: 2.44
+    } as any;
+
+    component.materialTypes = [
+      { id: 2, name: 'Area', unit: 'm2', description: '' } as any
+    ];
+
+    const sel: any = { material: mat, width: 0.6, length: 0.3, unit: 'm²' };
+
+    const cost = component.calculateCost(sel);
+
+    expect(cost).toBeCloseTo(60.47, 2);
+  });
+
   it('should filter accessories by search text', () => {
     component.accessories = [
       { id: 1, name: 'Alpha', description: 'Primero' } as any,

--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -621,11 +621,7 @@ export class AccesoriosComponent implements OnInit {
   calculateCost(sel: SelectedMaterial): number {
     const price = toNumber(sel.material.price);
     const investment = toNumber(sel.investment ?? sel.material.price);
-    if (sel.unit === 'm²') {
-      const width = toNumber(sel.width);
-      const length = toNumber(sel.length);
-      return width * length * investment;
-    }
+
     if (this.isAreaSel(sel)) {
       const width = toNumber(sel.width);
       const length = toNumber(sel.length);
@@ -633,10 +629,15 @@ export class AccesoriosComponent implements OnInit {
       const baseLength = toNumber(sel.material.length_m);
       const baseArea = baseWidth * baseLength;
       const area = width * length;
+
+      const totalPrice = investment > 0 ? investment : price;
+
       if (baseArea > 0) {
-        return (area / baseArea) * price;
+        const costPerSq = totalPrice / baseArea;
+        return costPerSq * area;
       }
-      return area * price;
+
+      return area * totalPrice;
     }
     if (this.isPieceSel(sel)) {
       const qty = toNumber(sel.quantity);


### PR DESCRIPTION
## Summary
- compute area costs using base dimensions even when unit is m²
- test area cost recalculation when unit is m²

## Testing
- `npm test` *(fails: 403 Forbidden for registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6865e6bee13c832d96772f49f4cce8ff