### PR TITLE
Fix child accessory unit price display

### DIFF
--- a/src/app/accesorios/accesorios.component.html
+++ b/src/app/accesorios/accesorios.component.html
@@ -277,8 +277,8 @@
               (input)="onChildInput()"
             />
           </td>
-          <td>{{ calculateChildCost(child) | number:'1.2-2' }}</td>
-          <td>{{ calculateChildPrice(child) | number:'1.2-2' }}</td>
+          <td>{{ child.accessory.cost | number:'1.2-2' }}</td>
+          <td>{{ child.accessory.price | number:'1.2-2' }}</td>
           <td>
             <button
               type="button"


### PR DESCRIPTION
## Summary
- fix unit cost and price displayed for child accessories during editing

## Testing
- `npm test --silent` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68660f82b224832dad0d1bd4450344a4