### PR TITLE
Fix child accessory unit pricing

### DIFF
--- a/src/app/accesorios/accesorios.component.ts
+++ b/src/app/accesorios/accesorios.component.ts
@@ -436,19 +436,22 @@ export class AccesoriosComponent implements OnInit {
                 ? (comps as any)
                 : [];
             this.selectedChildren = items.map((c) => {
+              const qty = this.toNumber(c.quantity ?? 1);
               const base: Accessory = (c as any).child ?? {
                 id: c.child_accessory_id,
                 name: (c as any).child_name ?? '',
                 description: (c as any).child_description ?? '',
               };
+              const cost = this.toNumber(c.cost);
+              const price = this.toNumber(c.price);
               const child: Accessory = {
                 ...base,
-                cost: c.cost,
-                price: c.price,
+                cost: qty > 0 ? cost / qty : cost,
+                price: qty > 0 ? price / qty : price,
               };
               return {
                 accessory: child,
-                quantity: c.quantity ?? 1,
+                quantity: qty,
                 component_id: c.id,
               } as SelectedAccessory;
             });


### PR DESCRIPTION
## Summary
- ensure child accessory cost/price are divided by quantity when editing

## Testing
- `npm test` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6866129f7d30832da2b594d2edacc8d1