### PR TITLE
Add AuthLoginPage and facade

### DIFF
--- a/src/app/features/auth/auth.module.ts
+++ b/src/app/features/auth/auth.module.ts
@@ -4,9 +4,15 @@ import { CommonModule } from '@angular/common';
 
 import { authRoutes } from './auth.routes';
 import { AuthShellPage } from './shell/auth-shell.page';
+import { AuthLoginPage } from './shell/auth-login.page';
+import { LoginFormComponent } from './ui/login-form.component';
 
 @NgModule({
-  imports: [CommonModule, RouterModule.forChild(authRoutes)],
-  declarations: [AuthShellPage],
+  imports: [
+    CommonModule,
+    RouterModule.forChild(authRoutes),
+    LoginFormComponent,
+  ],
+  declarations: [AuthShellPage, AuthLoginPage],
 })
 export class AuthModule {}

--- a/src/app/features/auth/auth.routes.ts
+++ b/src/app/features/auth/auth.routes.ts
@@ -1,10 +1,16 @@
 import { Routes } from '@angular/router';
 import { AuthShellPage } from './shell/auth-shell.page';
+import { AuthLoginPage } from './shell/auth-login.page';
 
 export const authRoutes: Routes = [
   {
     path: '',
     component: AuthShellPage,
-    children: [],
+    children: [
+      {
+        path: '',
+        component: AuthLoginPage,
+      },
+    ],
   },
 ];

--- a/src/app/features/auth/data-access/auth.facade.ts
+++ b/src/app/features/auth/data-access/auth.facade.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class AuthFacade {
+  private readonly loadingSubject = new BehaviorSubject<boolean>(false);
+  readonly isLoading$ = this.loadingSubject.asObservable();
+
+  private readonly errorSubject = new BehaviorSubject<string | null>(null);
+  readonly error$ = this.errorSubject.asObservable();
+
+  login(credentials: { email: string; password: string }): void {
+    this.loadingSubject.next(true);
+    this.errorSubject.next(null);
+    try {
+      const token = btoa(`${credentials.email}:${credentials.password}`);
+      this.setToken(token);
+    } catch (e) {
+      this.errorSubject.next('Login failed');
+    }
+    this.loadingSubject.next(false);
+  }
+
+  logout(): void {
+    this.setToken(null);
+  }
+
+  setToken(token: string | null): void {
+    if (token) {
+      localStorage.setItem('token', token);
+    } else {
+      localStorage.removeItem('token');
+    }
+  }
+}

--- a/src/app/features/auth/index.ts
+++ b/src/app/features/auth/index.ts
@@ -2,3 +2,5 @@ export * from './shell/auth-shell.page';
 export * from './auth.routes';
 export * from './auth.module';
 export * from './ui/login-form.component';
+export * from './shell/auth-login.page';
+export * from './data-access/auth.facade';

--- a/src/app/features/auth/shell/auth-login.page.html
+++ b/src/app/features/auth/shell/auth-login.page.html
@@ -1,0 +1,8 @@
+<app-login-form
+  [isLoading]="(isLoading$ | async) ?? false"
+  (login)="login($event)"
+></app-login-form>
+
+<div *ngIf="(error$ | async) as error">
+  <p>{{ error }}</p>
+</div>

--- a/src/app/features/auth/shell/auth-login.page.ts
+++ b/src/app/features/auth/shell/auth-login.page.ts
@@ -1,0 +1,18 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { AuthFacade } from '../data-access/auth.facade';
+
+@Component({
+  selector: 'app-auth-login',
+  templateUrl: './auth-login.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AuthLoginPage {
+  readonly isLoading$ = this.authFacade.isLoading$;
+  readonly error$ = this.authFacade.error$;
+
+  constructor(private readonly authFacade: AuthFacade) {}
+
+  login(credentials: { email: string; password: string }): void {
+    this.authFacade.login(credentials);
+  }
+}


### PR DESCRIPTION
## Summary
- add `AuthFacade` with `login`, `logout` and `setToken`
- create `AuthLoginPage` and template
- route to the new page and wire it up in the Auth module
- re-export facade and page from the auth index

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6875225a39b4832d91ec775834b96fc4