### PR TITLE
Fix Angular CLI for Node 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ This repository has been cleaned to serve as the starting point for a new projec
 
 - **Auth Module**: lazy loaded via `appRoutes` with preloading enabled.
   - `AuthShellPage` provides an internal `<router-outlet>` for child routes.
+
+## Development Requirements
+
+This project targets Angular 15 and can be built using **Node.js 16.13.2**.
+Newer versions of Angular CLI rely on Node 18 features such as
+`os.availableParallelism()`. Pinning the Angular packages to v15 allows the
+project to run with Node 16.

--- a/package.json
+++ b/package.json
@@ -12,21 +12,21 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "@angular-devkit/build-angular": "*",
-    "@angular/cli": "*",
-    "typescript": "*"
+    "@angular-devkit/build-angular": "^15.2.0",
+    "@angular/cli": "^15.2.0",
+    "typescript": "~4.8.0"
   },
   "dependencies": {
-    "@angular/common": "*",
-    "@angular/core": "*",
-    "@angular/forms": "*",
-    "@angular/router": "*",
-    "@auth0/angular-jwt": "*",
-    "bootstrap": "*",
-    "crypto-js": "*",
-    "ngx-toastr": "*",
-    "rxjs": "*",
-    "socket.io-client": "*",
-    "zone.js": "*"
+    "@angular/common": "^15.2.0",
+    "@angular/core": "^15.2.0",
+    "@angular/forms": "^15.2.0",
+    "@angular/router": "^15.2.0",
+    "@auth0/angular-jwt": "^5.1.0",
+    "bootstrap": "^5.3.0",
+    "crypto-js": "^4.1.1",
+    "ngx-toastr": "^16.1.0",
+    "rxjs": "^7.5.0",
+    "socket.io-client": "^4.7.2",
+    "zone.js": "^0.12.0"
   }
 }


### PR DESCRIPTION
## Summary
- pin Angular packages to v15 so the project can build with Node.js 16
- document Node 16 requirement in the README

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68781d860234832d9123303c9c4da6a2