### PR TITLE
Fix npm dependency conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@angular/common": "^15.2.0",
     "@angular/core": "^15.2.0",
     "@angular/forms": "^15.2.0",
+    "@angular/platform-browser": "^15.2.0",
+    "@angular/animations": "^15.2.0",
     "@angular/router": "^15.2.0",
     "@auth0/angular-jwt": "^5.1.0",
     "bootstrap": "^5.3.0",


### PR DESCRIPTION
## Summary
- add missing `@angular` packages to lock all Angular dependencies to v15

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68781f5371f8832d93aa11a02b948e97