### PR TITLE
Fix Angular dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ This project targets Angular 15 and can be built using **Node.js 16.13.2**.
 Newer versions of Angular CLI rely on Node 18 features such as
 `os.availableParallelism()`. Pinning the Angular packages to v15 allows the
 project to run with Node 16.
+
+When installing dependencies run `npm install` from the project root. If npm
+reports a peer dependency conflict related to `@angular-devkit/build-angular`,
+remove any globally installed Angular CLI packages and retry with
+`npm install --legacy-peer-deps`.

--- a/package.json
+++ b/package.json
@@ -12,17 +12,17 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "@angular-devkit/build-angular": "^15.2.0",
-    "@angular/cli": "^15.2.0",
-    "typescript": "~4.8.0"
+    "@angular-devkit/build-angular": "15.2.10",
+    "@angular/cli": "15.2.10",
+    "typescript": "4.8.4"
   },
   "dependencies": {
-    "@angular/common": "^15.2.0",
-    "@angular/core": "^15.2.0",
-    "@angular/forms": "^15.2.0",
-    "@angular/platform-browser": "^15.2.0",
-    "@angular/animations": "^15.2.0",
-    "@angular/router": "^15.2.0",
+    "@angular/common": "15.2.10",
+    "@angular/core": "15.2.10",
+    "@angular/forms": "15.2.10",
+    "@angular/platform-browser": "15.2.10",
+    "@angular/animations": "15.2.10",
+    "@angular/router": "15.2.10",
     "@auth0/angular-jwt": "^5.1.0",
     "bootstrap": "^5.3.0",
     "crypto-js": "^4.1.1",


### PR DESCRIPTION
## Summary
- pin Angular packages and TypeScript to 15.2.10
- document how to resolve npm peer dependency conflicts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68782033753c832dbd1b12124903977f