### PR TITLE
Improve login form persistence and dark style

### DIFF
--- a/src/app/features/auth/ui/login-form.component.ts
+++ b/src/app/features/auth/ui/login-form.component.ts
@@ -14,11 +14,16 @@ export class LoginFormComponent {
   @Output() login = new EventEmitter<{ email: string; password: string }>();
 
   readonly form = this.fb.group({
-    email: ['', [Validators.required, Validators.email]],
-    password: ['', [Validators.required, Validators.minLength(8)]],
+    email: [localStorage.getItem('loginEmail') || '', [Validators.required, Validators.email]],
+    password: [localStorage.getItem('loginPassword') || '', [Validators.required, Validators.minLength(8)]],
   });
 
-  constructor(private fb: FormBuilder) {}
+  constructor(private fb: FormBuilder) {
+    this.form.valueChanges.subscribe(({ email, password }) => {
+      localStorage.setItem('loginEmail', email ?? '');
+      localStorage.setItem('loginPassword', password ?? '');
+    });
+  }
 
   onSubmit(): void {
     if (this.form.valid && !this.isLoading) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,41 @@
 @import "bootstrap/dist/css/bootstrap.min.css";
+
+/* Dark theme inspired by ChatGPT */
+body {
+  background-color: #343541;
+  color: #ececf1;
+}
+
+app-login-form form {
+  background-color: #202123;
+  padding: 1.5rem;
+  border-radius: 8px;
+  max-width: 400px;
+  margin: 2rem auto;
+}
+
+app-login-form label {
+  margin-top: 0.5rem;
+}
+
+app-login-form input {
+  background-color: #40414f;
+  border: 1px solid #565869;
+  color: #ececf1;
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+  border-radius: 4px;
+}
+
+app-login-form button {
+  background-color: #10a37f;
+  border: none;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}
+
+app-login-form button:disabled {
+  opacity: 0.5;
+}


### PR DESCRIPTION
## Summary
- remember login credentials in browser localStorage
- create dark palette similar to ChatGPT

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6878366fa234832db218637efc6f2313