### PR TITLE
Fix API and socket URLs

### DIFF
--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,11 +1,11 @@
 {
   "/api": {
-    "target": "<URL BASE API>",
+    "target": "http://localhost:3000",
     "secure": false,
     "changeOrigin": true
   },
   "/socket.io": {
-    "target": "<URL SERVIDOR SOCKET>",
+    "target": "http://localhost:3000",
     "ws": true,
     "secure": false,
     "changeOrigin": true

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -6,8 +6,8 @@ import { EncryptService } from './encrypt.service';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
-  private readonly loginUrl = '/api/auth/login';
-  private readonly logoutUrl = '/api/auth/logout';
+  private readonly loginUrl = `${environment.apiUrl}/api/auth/login`;
+  private readonly logoutUrl = `${environment.apiUrl}/api/auth/logout`;
 
   constructor(private http: HttpClient, private cipher: EncryptService) {}
 

--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { io, Socket } from 'socket.io-client';
 import { BehaviorSubject } from 'rxjs';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class SocketService {
@@ -10,7 +11,7 @@ export class SocketService {
 
   connect(): void {
     const token = localStorage.getItem('sessionToken');
-    this.socket = io('<URL SERVIDOR SOCKET>', {
+    this.socket = io(environment.socketUrl, {
       auth: { token },
     });
 

--- a/src/app/shared/interceptors/jwt.interceptor.ts
+++ b/src/app/shared/interceptors/jwt.interceptor.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
 
 @Injectable()
 export class JwtInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    if (req.url.startsWith('/api/')) {
+    if (req.url.startsWith('/api/') || req.url.startsWith(environment.apiUrl)) {
       const token = localStorage.getItem('sessionToken');
       if (token) {
         req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,7 @@
 export const environment = {
   production: false,
   keyCipher: '<KEY_CIPHER>',
-  genericToken: '<GENERIC_TOKEN>'
+  genericToken: '<GENERIC_TOKEN>',
+  apiUrl: 'http://localhost:3000',
+  socketUrl: 'http://localhost:3000'
 };


### PR DESCRIPTION
## Summary
- configure development proxy to route API and socket requests to localhost:3000
- expose base URLs in environment file
- use environment URLs in AuthService and SocketService
- update JWT interceptor to match new base URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878352971b8832d94c0dc4a03576e74