### PR TITLE
Add logout button to dashboard view

### DIFF
--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -4,21 +4,35 @@ import { Router } from '@angular/router';
 import { SocketService } from '../../core/socket/socket.service';
 import { NotificationBadgeComponent } from '../../shared/components/notification-badge.component';
 import { NotificationListComponent } from '../../shared/components/notification-list.component';
+import { AuthFacade } from '../auth/data-access/auth.facade';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
   imports: [CommonModule, NotificationBadgeComponent, NotificationListComponent],
   template: `
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2>Dashboard</h2>
+      <button class="btn btn-outline-secondary" (click)="logout()">Logout</button>
+    </div>
     <app-notification-badge></app-notification-badge>
     <app-notification-list></app-notification-list>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DashboardComponent implements OnInit {
-  constructor(private socketService: SocketService, private router: Router) {}
+  constructor(
+    private socketService: SocketService,
+    private router: Router,
+    private authFacade: AuthFacade
+  ) {}
 
   ngOnInit(): void {
     this.socketService.connect();
+  }
+
+  logout(): void {
+    this.authFacade.logout();
+    this.router.navigate(['/auth/login']);
   }
 }


### PR DESCRIPTION
## Summary
- show a small header on the dashboard
- add logout button that calls the API via `AuthFacade`

## Testing
- `npm test -- --watch=false` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68783f3b9f84832da3cf4ec83f7aab5a