### PR TITLE
Implement notification creation

### DIFF
--- a/docs/NOTIFICATION_GUIDE.md
+++ b/docs/NOTIFICATION_GUIDE.md
@@ -1,0 +1,35 @@
+# Guía de notificaciones
+
+Este documento resume la comunicación por sockets y HTTP necesaria para utilizar el sistema de notificaciones del backend.
+
+## Eventos de socket
+- **notification:list**: se emite al conectarse y contiene la lista inicial.
+- **notification:badge**: indica cuántas notificaciones no vistas tiene el usuario.
+- **notification:new**: llega cuando el backend genera una notificación externa.
+- **notificacion-creada**: confirma la creación de una nueva notificación.
+- **notification:seen:ack**: respuesta al marcar una notificación como vista.
+
+## Crear una notificación
+Envíe un `POST` a `/api/notifications` con el mismo cuerpo que se envía por el evento `crea-notificacion`.
+
+```ts
+const payload = {
+  from_user_id: usuario.idDb,
+  from_company_id: usuario.company_id,
+  to_user_id: destinatario,
+  to_company_id: null,
+  tipo: 10,
+  data: { ... }
+};
+
+this.http.post(`${environment.apiUrl}/api/notifications`, payload).subscribe();
+this.socket.emit('crea-notificacion', payload);
+```
+
+## Marcar como vista
+
+```ts
+this.socket.emit('notification:seen', uuid);
+```
+
+Al recibir `notification:seen:ack` se actualiza el contador local.

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -15,6 +15,7 @@ import { AuthFacade } from '../auth/data-access/auth.facade';
       <h2>Dashboard</h2>
       <button class="btn btn-outline-secondary" (click)="logout()">Logout</button>
     </div>
+    <button class="btn btn-primary mb-3" (click)="createSample()">Crear Notificación</button>
     <app-notification-badge></app-notification-badge>
     <app-notification-list></app-notification-list>
   `,
@@ -29,6 +30,18 @@ export class DashboardComponent implements OnInit {
 
   ngOnInit(): void {
     this.socketService.connect();
+  }
+
+  createSample(): void {
+    const payload = {
+      from_user_id: 1,
+      from_company_id: null,
+      to_user_id: 1,
+      to_company_id: null,
+      tipo: 10,
+      data: { title: 'Demo', message: 'Prueba de notificacion' },
+    };
+    this.socketService.createNotification(payload);
   }
 
   logout(): void {


### PR DESCRIPTION
## Summary
- add socket HTTP integration to create notifications
- update dashboard to allow sending a sample notification
- document notification usage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6878425bb168832d812cbd4ee178e7dc