### PR TITLE
Implement Socket.IO notification client

### DIFF
--- a/src/app/core/socket/notification.types.ts
+++ b/src/app/core/socket/notification.types.ts
@@ -1,0 +1,32 @@
+export interface Notificacion {
+  origen: number | null;
+  destino: number;
+  tipo: number;
+  data: number;
+}
+
+export interface NotificationSeen {
+  uuid: string;
+}
+
+export interface NotificationUpdateStatus {
+  uuid: string;
+  status: number;
+}
+
+export interface NotificationDelete {
+  uuid: string;
+}
+
+export interface NotificationGet {
+  uuid: string;
+}
+
+export interface NotificationListParams {
+  page?: number;
+  limit?: number;
+}
+
+export interface NotificationHistory {
+  uuid: string;
+}

--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -1,8 +1,16 @@
 import { Injectable } from '@angular/core';
 import { io, Socket } from 'socket.io-client';
 import { BehaviorSubject } from 'rxjs';
-import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
+import {
+  Notificacion,
+  NotificationDelete,
+  NotificationGet,
+  NotificationHistory,
+  NotificationListParams,
+  NotificationSeen,
+  NotificationUpdateStatus,
+} from './notification.types';
 
 @Injectable({ providedIn: 'root' })
 export class SocketService {
@@ -10,50 +18,118 @@ export class SocketService {
   notifications$ = new BehaviorSubject<any[]>([]);
   badge$ = new BehaviorSubject<number>(0);
 
-  constructor(private http: HttpClient) {}
+  constructor() {}
 
   connect(): void {
-    const token = localStorage.getItem('sessionToken');
+    const token = localStorage.getItem('sessionToken') || '';
     this.socket = io(environment.socketUrl, {
-      auth: { token },
+      query: { token },
+      extraHeaders: { Authorization: `Bearer ${token}` },
     });
 
     this.socket.on('notification:list', (list) => this.notifications$.next(list));
-    this.socket.on('notification:new', (n) => {
-      this.notifications$.next([n, ...this.notifications$.value]);
+    this.socket.on('notification:badge', (b) => this.badge$.next(b));
+
+    this.socket.on('notification:list:ack', (resp) => {
+      if (!resp?.error) {
+        this.notifications$.next(resp.data);
+      }
     });
+
+    this.socket.on('notification:unseen-count:ack', (resp) => {
+      if (!resp?.error) {
+        this.badge$.next(resp.data);
+      }
+    });
+
     this.socket.on('notificacion-creada', (resp) => {
       if (!resp?.error && resp?.data) {
         this.notifications$.next([resp.data, ...this.notifications$.value]);
         this.badge$.next(this.badge$.value + 1);
       }
     });
-    this.socket.on('notification:badge', (b) => this.badge$.next(b));
-    this.socket.on('notification:seen:ack', (uuid) => {
-      this.notifications$.next(
-        this.notifications$.value.map((n) =>
-          n.uuid === uuid ? { ...n, seen: true } : n
-        )
-      );
-      this.badge$.next(this.badge$.value - 1);
+
+    this.socket.on('notification:seen:ack', (resp) => {
+      if (!resp?.error) {
+        const uuid = resp.data;
+        this.notifications$.next(
+          this.notifications$.value.map((n) =>
+            n.uuid === uuid ? { ...n, seen: true } : n
+          )
+        );
+        this.badge$.next(Math.max(this.badge$.value - 1, 0));
+      }
     });
+
+    this.socket.on('notification:update-status:ack', (resp) => {
+      if (!resp?.error) {
+        this.notifications$.next(
+          this.notifications$.value.map((n) =>
+            n.uuid === resp.data.uuid ? { ...n, status: resp.data.status } : n
+          )
+        );
+      }
+    });
+
+    this.socket.on('notification:delete:ack', (resp) => {
+      if (!resp?.error) {
+        const uuid = resp.data;
+        this.notifications$.next(
+          this.notifications$.value.filter((n) => n.uuid !== uuid)
+        );
+      }
+    });
+
     this.socket.on('notification:deleted', (uuid) => {
       this.notifications$.next(
         this.notifications$.value.filter((n) => n.uuid !== uuid)
       );
     });
+
+    this.socket.on('notification:get:ack', (resp) => {
+      if (!resp?.error && resp?.data) {
+        const n = resp.data;
+        const exists = this.notifications$.value.some((x) => x.uuid === n.uuid);
+        if (exists) {
+          this.notifications$.next(
+            this.notifications$.value.map((x) => (x.uuid === n.uuid ? n : x))
+          );
+        } else {
+          this.notifications$.next([n, ...this.notifications$.value]);
+        }
+      }
+    });
   }
 
   markSeen(uuid: string): void {
-    this.socket?.emit('notification:seen', uuid);
+    this.socket?.emit('notification:seen', { uuid } as NotificationSeen);
   }
 
   delete(uuid: string): void {
-    this.socket?.emit('notification:delete', uuid);
+    this.socket?.emit('notification:delete', { uuid } as NotificationDelete);
   }
 
-  createNotification(payload: any): void {
-    this.http.post(`${environment.apiUrl}/api/notifications`, payload).subscribe();
+  createNotification(payload: Notificacion): void {
     this.socket?.emit('crea-notificacion', payload);
+  }
+
+  requestList(params: NotificationListParams = {}): void {
+    this.socket?.emit('notification:list', params);
+  }
+
+  requestUnseenCount(): void {
+    this.socket?.emit('notification:unseen-count');
+  }
+
+  updateStatus(payload: NotificationUpdateStatus): void {
+    this.socket?.emit('notification:update-status', payload);
+  }
+
+  history(payload: NotificationHistory): void {
+    this.socket?.emit('notification:history', payload);
+  }
+
+  getNotification(payload: NotificationGet): void {
+    this.socket?.emit('notification:get', payload);
   }
 }

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { SocketService } from '../../core/socket/socket.service';
+import { Notificacion } from '../../core/socket/notification.types';
 import { NotificationBadgeComponent } from '../../shared/components/notification-badge.component';
 import { NotificationListComponent } from '../../shared/components/notification-list.component';
 import { AuthFacade } from '../auth/data-access/auth.facade';
@@ -33,13 +34,11 @@ export class DashboardComponent implements OnInit {
   }
 
   createSample(): void {
-    const payload = {
-      from_user_id: 1,
-      from_company_id: null,
-      to_user_id: 1,
-      to_company_id: null,
+    const payload: Notificacion = {
+      origen: null,
+      destino: 1,
       tipo: 10,
-      data: { title: 'Demo', message: 'Prueba de notificacion' },
+      data: 0,
     };
     this.socketService.createNotification(payload);
   }


### PR DESCRIPTION
## Summary
- add types for notification payloads
- expand SocketService to use JWT token in connection and handle ack events
- expose methods for requesting notification list, unseen count, updating status, etc.
- adjust dashboard demo to use new Notificacion type

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687850d1358c832dace09c15b2d33401