### PR TITLE
Add socket service test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ When installing dependencies run `npm install` from the project root. If npm
 reports a peer dependency conflict related to `@angular-devkit/build-angular`,
 remove any globally installed Angular CLI packages and retry with
 `npm install --legacy-peer-deps`.
+
+## Socket tests
+
+Run `npm test` to execute a lightweight test suite for the `SocketService`.
+The tests use stubbed versions of Angular and Socket.IO so they work even
+without installing the full dependency tree.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository has been cleaned to serve as the starting point for a new project. Feel free to add your own files and configurations.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "tsc -p tsconfig.spec.json && NODE_PATH=tests/node_modules node dist/test/tests/socket.service.test.js",
     "start": "ng serve --proxy-config proxy.conf.json --open"
   },
   "keywords": [],

--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -26,6 +26,16 @@ export class SocketService {
       query: { token },
       extraHeaders: { Authorization: `Bearer ${token}` },
     });
+    this.registerHandlers();
+  }
+
+  /**
+   * Registers all socket listeners. Extracted for easier testing.
+   */
+  private registerHandlers(): void {
+    if (!this.socket) {
+      return;
+    }
 
     this.socket.on('notification:list', (list) => this.notifications$.next(list));
     this.socket.on('notification:badge', (b) => this.badge$.next(b));
@@ -99,6 +109,14 @@ export class SocketService {
         }
       }
     });
+  }
+
+  /**
+   * Allows injecting a mock socket when running tests.
+   */
+  setSocketForTesting(socket: Pick<Socket, 'on' | 'emit'>): void {
+    this.socket = socket as Socket;
+    this.registerHandlers();
   }
 
   markSeen(uuid: string): void {

--- a/tests/node_modules/@angular/core/index.js
+++ b/tests/node_modules/@angular/core/index.js
@@ -1,0 +1,1 @@
+module.exports = { Injectable: () => () => {} };

--- a/tests/node_modules/rxjs/index.js
+++ b/tests/node_modules/rxjs/index.js
@@ -1,0 +1,5 @@
+class BehaviorSubject {
+  constructor(v) { this.value = v; }
+  next(v) { this.value = v; }
+}
+module.exports = { BehaviorSubject };

--- a/tests/node_modules/socket.io-client/index.js
+++ b/tests/node_modules/socket.io-client/index.js
@@ -1,0 +1,1 @@
+module.exports = { io: () => ({ on() {}, emit() {} }) };

--- a/tests/socket.service.test.ts
+++ b/tests/socket.service.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import { EventEmitter } from 'events';
+import { SocketService } from '../src/app/core/socket/socket.service';
+
+class FakeSocket extends EventEmitter {
+  public emitted: {event: string; payload: any}[] = [];
+  emit(event: string, payload?: any): boolean {
+    this.emitted.push({ event, payload });
+    return super.emit(event, payload);
+  }
+}
+
+test('service updates list on notification:list', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  const list = [{ uuid: '1', seen: false }];
+  socket.emit('notification:list', list);
+  assert.deepStrictEqual(service.notifications$.value, list);
+});
+
+test('markSeen emits correct payload', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  service.markSeen('123');
+  assert.deepStrictEqual(socket.emitted[0], { event: 'notification:seen', payload: { uuid: '123' } });
+});
+
+test('notification:seen:ack updates badge and notifications', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  const list = [{ uuid: 'a', seen: false }];
+  socket.emit('notification:list', list);
+  socket.emit('notification:seen:ack', { data: 'a' });
+  assert.strictEqual(service.badge$.value, 0);
+  assert.strictEqual(service.notifications$.value[0].seen, true);
+});

--- a/tests/stubs/angular-core.ts
+++ b/tests/stubs/angular-core.ts
@@ -1,0 +1,3 @@
+export function Injectable(_?: any) {
+  return function(_: any) {};
+}

--- a/tests/stubs/rxjs.ts
+++ b/tests/stubs/rxjs.ts
@@ -1,0 +1,6 @@
+export class BehaviorSubject<T> {
+  private _value: T;
+  constructor(init: T) { this._value = init; }
+  next(v: T) { this._value = v; }
+  get value() { return this._value; }
+}

--- a/tests/stubs/socket.io-client.ts
+++ b/tests/stubs/socket.io-client.ts
@@ -1,0 +1,10 @@
+export interface Socket {
+  on(event: string, cb: (...args: any[]) => void): this;
+  emit(event: string, payload?: any): void;
+}
+export function io(_url?: string, _options?: any): Socket {
+  return {
+    on() { return this; },
+    emit() {}
+  } as Socket;
+}

--- a/tests/typings/node.d.ts
+++ b/tests/typings/node.d.ts
@@ -1,0 +1,3 @@
+declare module 'node:test';
+declare module 'node:assert';
+declare module 'events';

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/test",
+    "module": "commonjs",
+    "target": "es2020",
+    "importHelpers": false,
+    "skipLibCheck": true,
+    "paths": {
+      "socket.io-client": ["tests/stubs/socket.io-client"],
+      "rxjs": ["tests/stubs/rxjs"],
+      "@angular/core": ["tests/stubs/angular-core"]
+    }
+  },
+  "include": ["tests/**/*.ts", "src/app/core/socket/**/*.ts", "tests/typings/**/*.d.ts"],
+  "typeAcquisition": {
+    "enable": false
+  }
+}


### PR DESCRIPTION
## Summary
- add helper method in `SocketService` for easier testing
- create basic tests using Node's test runner
- include minimal stubs for Angular, RxJS and Socket.IO
- document how to run the socket tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68785385e970832da0e8af867934074d