### PR TITLE
Add console logs for notification debugging

### DIFF
--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -22,6 +22,7 @@ export class SocketService {
 
   connect(): void {
     const token = localStorage.getItem('sessionToken') || '';
+    console.log('SocketService: connecting to', environment.socketUrl);
     this.socket = io(environment.socketUrl, {
       query: { token },
       extraHeaders: { Authorization: `Bearer ${token}` },
@@ -120,14 +121,17 @@ export class SocketService {
   }
 
   markSeen(uuid: string): void {
+    console.log('SocketService: markSeen', uuid);
     this.socket?.emit('notification:seen', { uuid } as NotificationSeen);
   }
 
   delete(uuid: string): void {
+    console.log('SocketService: delete', uuid);
     this.socket?.emit('notification:delete', { uuid } as NotificationDelete);
   }
 
   createNotification(payload: Notificacion): void {
+    console.log('SocketService: createNotification', payload);
     this.socket?.emit('crea-notificacion', payload);
   }
 

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -34,6 +34,7 @@ export class DashboardComponent implements OnInit {
   }
 
   createSample(): void {
+    console.log('DashboardComponent: createSample clicked');
     const payload: Notificacion = {
       origen: null,
       destino: 1,


### PR DESCRIPTION
## Summary
- log when clicking the sample notification button
- log socket connection and emit actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687855f66eec832d9ef4c293ec928903