### PR TITLE
Update notification payload structure

### DIFF
--- a/src/app/core/socket/notification.types.ts
+++ b/src/app/core/socket/notification.types.ts
@@ -1,8 +1,12 @@
 export interface Notificacion {
-  origen: number | null;
-  destino: number;
-  tipo: number;
-  data: number;
+  from_company_id: number;
+  from_user_id: number;
+  to_company_id: number;
+  to_user_id: number;
+  title: string;
+  body: string;
+  payload: any;
+  channel: string;
 }
 
 export interface NotificationSeen {

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -36,10 +36,14 @@ export class DashboardComponent implements OnInit {
   createSample(): void {
     console.log('DashboardComponent: createSample clicked');
     const payload: Notificacion = {
-      origen: null,
-      destino: 1,
-      tipo: 10,
-      data: 0,
+      from_company_id: 66,
+      from_user_id: 84,
+      to_company_id: 83,
+      to_user_id: 102,
+      title: 'Título de la notificación',
+      body: 'Cuerpo del mensaje',
+      payload: {},
+      channel: 'email',
     };
     this.socketService.createNotification(payload);
   }

--- a/tests/socket.service.test.ts
+++ b/tests/socket.service.test.ts
@@ -41,3 +41,26 @@ test('notification:seen:ack updates badge and notifications', () => {
   assert.strictEqual(service.badge$.value, 0);
   assert.strictEqual(service.notifications$.value[0].seen, true);
 });
+
+test('createNotification emits correct payload', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  const payload = {
+    from_company_id: 1,
+    from_user_id: 2,
+    to_company_id: 3,
+    to_user_id: 4,
+    title: 't',
+    body: 'b',
+    payload: {},
+    channel: 'email',
+  };
+
+  service.createNotification(payload as any);
+  assert.deepStrictEqual(socket.emitted[0], {
+    event: 'crea-notificacion',
+    payload,
+  });
+});


### PR DESCRIPTION
## Summary
- restructure notification payload to match backend
- update dashboard sample notification data
- test createNotification emits correct payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687869a15d88832dabfaf1b56745b958