### PR TITLE
Add socket connection error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ remove any globally installed Angular CLI packages and retry with
 Run `npm test` to execute a lightweight test suite for the `SocketService`.
 The tests use stubbed versions of Angular and Socket.IO so they work even
 without installing the full dependency tree.
+
+The `SocketService` now logs a message when the connection succeeds and prints
+any socket connection errors to the console. This helps diagnose networking
+issues during development.

--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -27,6 +27,12 @@ export class SocketService {
       query: { token },
       extraHeaders: { Authorization: `Bearer ${token}` },
     });
+    this.socket.on('connect', () =>
+      console.log('SocketService: connected to socket')
+    );
+    this.socket.on('connect_error', (err) =>
+      console.error('SocketService: connection error', err)
+    );
     this.registerHandlers();
   }
 
@@ -117,6 +123,12 @@ export class SocketService {
    */
   setSocketForTesting(socket: Pick<Socket, 'on' | 'emit'>): void {
     this.socket = socket as Socket;
+    this.socket.on('connect', () =>
+      console.log('SocketService: connected to socket')
+    );
+    this.socket.on('connect_error', (err) =>
+      console.error('SocketService: connection error', err)
+    );
     this.registerHandlers();
   }
 

--- a/tests/socket.service.test.ts
+++ b/tests/socket.service.test.ts
@@ -64,3 +64,21 @@ test('createNotification emits correct payload', () => {
     payload,
   });
 });
+
+test('logs error on connection failure', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  let captured: any;
+  const orig = console.error;
+  console.error = (_msg: any, err?: any) => {
+    captured = err ?? _msg;
+  };
+
+  const error = new Error('fail');
+  socket.emit('connect_error', error);
+
+  console.error = orig;
+  assert.strictEqual(captured, error);
+});


### PR DESCRIPTION
## Summary
- log socket connection events for easier debugging
- document connection logging in README
- test connection failure logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68786b5402b8832d9e2f1ab8fb97ff49