### PR TITLE
Fix socket.io-client v2 import

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "crypto-js": "^4.1.1",
     "ngx-toastr": "^16.1.0",
     "rxjs": "^7.5.0",
-    "socket.io-client": "^4.7.2",
+    "socket.io-client": "^2.4.1",
     "zone.js": "^0.12.0"
   }
 }

--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { io, Socket } from 'socket.io-client';
+import io, { Socket } from 'socket.io-client';
 import { BehaviorSubject } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import {

--- a/tests/node_modules/socket.io-client/index.js
+++ b/tests/node_modules/socket.io-client/index.js
@@ -1,1 +1,6 @@
-module.exports = { io: () => ({ on() {}, emit() {} }) };
+function io() {
+  return { on() {}, emit() {} };
+}
+
+module.exports = io;
+module.exports.io = io;

--- a/tests/stubs/socket.io-client.ts
+++ b/tests/stubs/socket.io-client.ts
@@ -2,9 +2,14 @@ export interface Socket {
   on(event: string, cb: (...args: any[]) => void): this;
   emit(event: string, payload?: any): void;
 }
+
 export function io(_url?: string, _options?: any): Socket {
   return {
-    on() { return this; },
-    emit() {}
+    on() {
+      return this;
+    },
+    emit() {},
   } as Socket;
 }
+
+export default io;


### PR DESCRIPTION
## Summary
- update to socket.io-client v2.4.1 and adjust import
- allow default export for socket.io-client stubs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68786f79dc70832d8c120f10f24cd51c