### PR TITLE
Add notification table display

### DIFF
--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -4,21 +4,27 @@ import { Router } from '@angular/router';
 import { SocketService } from '../../core/socket/socket.service';
 import { Notificacion } from '../../core/socket/notification.types';
 import { NotificationBadgeComponent } from '../../shared/components/notification-badge.component';
-import { NotificationListComponent } from '../../shared/components/notification-list.component';
+import { NotificationTableComponent } from '../../shared/components/notification-table.component';
 import { AuthFacade } from '../auth/data-access/auth.facade';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [CommonModule, NotificationBadgeComponent, NotificationListComponent],
+  imports: [
+    CommonModule,
+    NotificationBadgeComponent,
+    NotificationTableComponent,
+  ],
   template: `
     <div class="d-flex justify-content-between align-items-center mb-3">
       <h2>Dashboard</h2>
       <button class="btn btn-outline-secondary" (click)="logout()">Logout</button>
     </div>
-    <button class="btn btn-primary mb-3" (click)="createSample()">Crear Notificación</button>
+    <div class="d-flex align-items-start mb-3">
+      <button class="btn btn-primary me-3" (click)="createSample()">Crear Notificación</button>
+      <app-notification-table></app-notification-table>
+    </div>
     <app-notification-badge></app-notification-badge>
-    <app-notification-list></app-notification-list>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/app/shared/components/notification-table.component.ts
+++ b/src/app/shared/components/notification-table.component.ts
@@ -1,0 +1,43 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SocketService } from '../../core/socket/socket.service';
+
+@Component({
+  selector: 'app-notification-table',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <table class="table table-sm mb-0">
+      <thead>
+        <tr>
+          <th>Título</th>
+          <th>Fecha</th>
+          <th>Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let n of notifications$ | async">
+          <td [class.fw-bold]="!n.seen">{{ n.title }}</td>
+          <td>{{ n.date }}</td>
+          <td>
+            <button (click)="markSeen(n.uuid)" class="btn btn-sm btn-link">Marcar vista</button>
+            <button (click)="delete(n.uuid)" class="btn btn-sm btn-link text-danger">Eliminar</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class NotificationTableComponent {
+  readonly notifications$ = this.socketService.notifications$;
+  constructor(private socketService: SocketService) {}
+
+  markSeen(uuid: string): void {
+    this.socketService.markSeen(uuid);
+  }
+
+  delete(uuid: string): void {
+    this.socketService.delete(uuid);
+  }
+}


### PR DESCRIPTION
## Summary
- add `NotificationTableComponent` to display notifications in a table
- show the table next to the "Crear Notificación" button on the dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687874ca0c34832dbc15afd695735019