### PR TITLE
Add list requests on dashboard init

### DIFF
--- a/docs/NOTIFICATION_GUIDE.md
+++ b/docs/NOTIFICATION_GUIDE.md
@@ -8,6 +8,8 @@ Este documento resume la comunicación por sockets y HTTP necesaria para utiliza
 - **notification:new**: llega cuando el backend genera una notificación externa.
 - **notificacion-creada**: confirma la creación de una nueva notificación.
 - **notification:seen:ack**: respuesta al marcar una notificación como vista.
+- **notification:get:ack**: devuelve la notificación solicitada por `uuid`. El
+  frontend actualiza la tabla de notificaciones al recibir este evento.
 
 ## Crear una notificación
 Envíe un `POST` a `/api/notifications` con el mismo cuerpo que se envía por el evento `crea-notificacion`.
@@ -33,3 +35,10 @@ this.socket.emit('notification:seen', uuid);
 ```
 
 Al recibir `notification:seen:ack` se actualiza el contador local.
+
+## Obtener una notificación individual
+
+```ts
+socket.emit('notification:get', { uuid: '123' });
+// Al recibir `notification:get:ack` el servicio agrega o actualiza la notificación
+```

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -37,6 +37,8 @@ export class DashboardComponent implements OnInit {
 
   ngOnInit(): void {
     this.socketService.connect();
+    this.socketService.requestList();
+    this.socketService.requestUnseenCount();
   }
 
   createSample(): void {

--- a/tests/socket.service.test.ts
+++ b/tests/socket.service.test.ts
@@ -65,6 +65,37 @@ test('createNotification emits correct payload', () => {
   });
 });
 
+test('getNotification emits correct payload', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  service.getNotification({ uuid: '42' } as any);
+  assert.deepStrictEqual(socket.emitted[0], {
+    event: 'notification:get',
+    payload: { uuid: '42' },
+  });
+});
+
+test('notification:get:ack adds or updates notification', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  const initial = [{ uuid: '1', title: 'old' }];
+  socket.emit('notification:list', initial);
+
+  const update = { uuid: '1', title: 'new' };
+  socket.emit('notification:get:ack', { data: update });
+  assert.deepStrictEqual(service.notifications$.value[0], update);
+
+  const added = { uuid: '2', title: 'added' };
+  socket.emit('notification:get:ack', { data: added });
+  assert.strictEqual(service.notifications$.value.length, 2);
+  assert.deepStrictEqual(service.notifications$.value[0], added);
+  assert.deepStrictEqual(service.notifications$.value[1], update);
+});
+
 test('logs error on connection failure', () => {
   const service = new SocketService();
   const socket = new FakeSocket();


### PR DESCRIPTION
## Summary
- fetch notifications and unseen count when dashboard loads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68787dfdbcec832d9e46692cd739b00f