### PR TITLE
Fix notification badge object value

### DIFF
--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -51,7 +51,8 @@ export class SocketService {
     });
     this.socket.on('notification:badge', (b) => {
       console.log('SocketService: notification:badge', b);
-      this.badge$.next(b);
+      const count = typeof b === 'number' ? b : b?.data ?? b?.count ?? 0;
+      this.badge$.next(count);
     });
 
     this.socket.on('notification:list:ack', (resp) => {

--- a/tests/socket.service.test.ts
+++ b/tests/socket.service.test.ts
@@ -42,6 +42,15 @@ test('notification:seen:ack updates badge and notifications', () => {
   assert.strictEqual(service.notifications$.value[0].seen, true);
 });
 
+test('notification:badge handles object payloads', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  socket.emit('notification:badge', { data: 5 });
+  assert.strictEqual(service.badge$.value, 5);
+});
+
 test('createNotification emits correct payload', () => {
   const service = new SocketService();
   const socket = new FakeSocket();


### PR DESCRIPTION
## Summary
- parse `notification:badge` event payload to extract the count
- test badge behavior when socket emits an object

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68788328a7cc832d9a1b994e4334fbbb