### PR TITLE
Fix list ack payload handling

### DIFF
--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -58,7 +58,12 @@ export class SocketService {
     this.socket.on('notification:list:ack', (resp) => {
       console.log('SocketService: notification:list:ack', resp);
       if (!resp?.error) {
-        this.notifications$.next(resp.data);
+        const arr = Array.isArray(resp.data)
+          ? resp.data
+          : Array.isArray(resp?.data?.data)
+          ? resp.data.data
+          : [];
+        this.notifications$.next(arr);
       }
     });
 

--- a/tests/socket.service.test.ts
+++ b/tests/socket.service.test.ts
@@ -21,6 +21,16 @@ test('service updates list on notification:list', () => {
   assert.deepStrictEqual(service.notifications$.value, list);
 });
 
+test('notification:list:ack handles object payloads', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  const list = [{ uuid: 'a' }];
+  socket.emit('notification:list:ack', { data: { data: list } });
+  assert.deepStrictEqual(service.notifications$.value, list);
+});
+
 test('markSeen emits correct payload', () => {
   const service = new SocketService();
   const socket = new FakeSocket();


### PR DESCRIPTION
## Summary
- normalize `notification:list:ack` data to avoid `[object Object]` output
- test for nested list ack payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68788439f96c832db8283844538bba6d