### PR TITLE
Fix notification badge count

### DIFF
--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -70,7 +70,11 @@ export class SocketService {
     this.socket.on('notification:unseen-count:ack', (resp) => {
       console.log('SocketService: notification:unseen-count:ack', resp);
       if (!resp?.error) {
-        this.badge$.next(resp.data);
+        const count =
+          typeof resp.data === 'number'
+            ? resp.data
+            : resp?.data?.data ?? resp?.data?.count ?? 0;
+        this.badge$.next(count);
       }
     });
 

--- a/tests/socket.service.test.ts
+++ b/tests/socket.service.test.ts
@@ -132,3 +132,12 @@ test('logs error on connection failure', () => {
   console.error = orig;
   assert.strictEqual(captured, error);
 });
+
+test('notification:unseen-count:ack handles nested payloads', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  socket.emit('notification:unseen-count:ack', { data: { count: 3 } });
+  assert.strictEqual(service.badge$.value, 3);
+});


### PR DESCRIPTION
## Summary
- handle nested `notification:unseen-count:ack` payloads when updating the badge count
- test that nested payloads update the badge correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687887731414832d80a73885607c2645