### PR TITLE
Populate notification source from cookies

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { map } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import { EncryptService } from './encrypt.service';
+import { setCookie } from '../../shared/utils/cookies';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
@@ -28,6 +29,13 @@ export class AuthService {
           }
           if (tokens.refreshToken) {
             localStorage.setItem('refreshToken', tokens.refreshToken);
+          }
+          const user = decrypted.login?.usuario;
+          if (user?.company_id) {
+            setCookie('from_company_id', String(user.company_id));
+          }
+          if (user?.idDb) {
+            setCookie('from_user_id', String(user.idDb));
           }
           return decrypted;
         })

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { SocketService } from '../../core/socket/socket.service';
 import { Notificacion } from '../../core/socket/notification.types';
+import { getCookie } from '../../shared/utils/cookies';
 import { NotificationBadgeComponent } from '../../shared/components/notification-badge.component';
 import { NotificationTableComponent } from '../../shared/components/notification-table.component';
 import { AuthFacade } from '../auth/data-access/auth.facade';
@@ -43,9 +44,11 @@ export class DashboardComponent implements OnInit {
 
   createSample(): void {
     console.log('DashboardComponent: createSample clicked');
+    const fromCompanyId = Number(getCookie('from_company_id')) || 0;
+    const fromUserId = Number(getCookie('from_user_id')) || 0;
     const payload: Notificacion = {
-      from_company_id: 66,
-      from_user_id: 84,
+      from_company_id: fromCompanyId,
+      from_user_id: fromUserId,
       to_company_id: 83,
       to_user_id: 102,
       title: 'Título de la notificación',

--- a/src/app/shared/utils/cookies.ts
+++ b/src/app/shared/utils/cookies.ts
@@ -1,0 +1,14 @@
+export function setCookie(name: string, value: string): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/`;
+}
+
+export function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+  return match ? decodeURIComponent(match[1]) : null;
+}


### PR DESCRIPTION
## Summary
- set helpers to manage cookies
- store `from_company_id` and `from_user_id` cookies during login
- read those cookies when creating a sample notification

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879187d97d0832d904e47918517e0b0