### PR TITLE
Handle cookie cleanup and socket disconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository has been cleaned to serve as the starting point for a new project. Feel free to add your own files and configurations.",
   "main": "index.js",
   "scripts": {
-    "test": "tsc -p tsconfig.spec.json && NODE_PATH=tests/node_modules node dist/test/tests/socket.service.test.js",
+    "test": "tsc -p tsconfig.spec.json && NODE_PATH=tests/node_modules:tests/stubs node dist/test/tests/socket.service.test.js && NODE_PATH=tests/node_modules:tests/stubs node dist/test/tests/auth.service.test.js",
     "start": "ng serve --proxy-config proxy.conf.json --open"
   },
   "keywords": [],

--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -55,9 +55,9 @@ export class SocketService {
       this.badge$.next(count);
     });
 
-    this.socket.on('notification:get:ack', (resp) => {
+    this.socket.on('notification:list:ack', (resp) => {
       if (!resp?.error) {
-        console.log('notification:get:ack', resp)
+        console.log('notification:list:ack', resp)
         const arr = Array.isArray(resp.data)
           ? resp.data
           : Array.isArray(resp?.data?.data)
@@ -190,5 +190,12 @@ export class SocketService {
 
   getNotification(payload: NotificationGet): void {
     this.socket?.emit('notification:get', payload);
+  }
+
+  disconnect(): void {
+    this.socket?.disconnect();
+    this.socket = undefined;
+    this.notifications$.next([]);
+    this.badge$.next(0);
   }
 }

--- a/src/app/features/auth/data-access/auth.facade.ts
+++ b/src/app/features/auth/data-access/auth.facade.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, tap } from 'rxjs';
 import { AuthService } from '../../../core/auth/auth.service';
+import { removeCookie } from '../../../shared/utils/cookies';
 
 @Injectable({ providedIn: 'root' })
 export class AuthFacade {
@@ -43,5 +44,7 @@ export class AuthFacade {
   private clearTokens(): void {
     localStorage.removeItem('sessionToken');
     localStorage.removeItem('refreshToken');
+    removeCookie('from_company_id');
+    removeCookie('from_user_id');
   }
 }

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -1,4 +1,9 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  ChangeDetectionStrategy,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { SocketService } from '../../core/socket/socket.service';
@@ -29,7 +34,7 @@ import { AuthFacade } from '../auth/data-access/auth.facade';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DashboardComponent implements OnInit {
+export class DashboardComponent implements OnInit, OnDestroy {
   constructor(
     private socketService: SocketService,
     private router: Router,
@@ -60,7 +65,12 @@ export class DashboardComponent implements OnInit {
   }
 
   logout(): void {
+    this.socketService.disconnect();
     this.authFacade.logout();
     this.router.navigate(['/auth/login']);
+  }
+
+  ngOnDestroy(): void {
+    this.socketService.disconnect();
   }
 }

--- a/src/app/shared/utils/cookies.ts
+++ b/src/app/shared/utils/cookies.ts
@@ -12,3 +12,10 @@ export function getCookie(name: string): string | null {
   const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
   return match ? decodeURIComponent(match[1]) : null;
 }
+
+export function removeCookie(name: string): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+}

--- a/tests/auth.service.test.ts
+++ b/tests/auth.service.test.ts
@@ -1,0 +1,59 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import { AuthService } from '../src/app/core/auth/auth.service';
+import { getCookie } from '../src/app/shared/utils/cookies';
+
+class FakeObservable<T> {
+  constructor(private value: T) {}
+  pipe(op: any) {
+    return op(this);
+  }
+  subscribe(cb: (v: T) => void) {
+    cb(this.value);
+  }
+}
+
+class FakeHttpClient {
+  constructor(private resp: string) {}
+  post(_url: string, _body: any, _opts: any) {
+    return new FakeObservable(this.resp);
+  }
+}
+
+class FakeCipher {
+  encrypt(data: any) {
+    return JSON.stringify(data);
+  }
+  decrypt(text: string) {
+    return JSON.parse(text);
+  }
+}
+
+test('login sets user/company cookies', () => {
+  (globalThis as any).document = {
+    _cookies: {} as Record<string, string>,
+    get cookie() {
+      return Object.entries(this._cookies)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('; ');
+    },
+    set cookie(val: string) {
+      const [pair] = val.split(';');
+      const [name, v] = pair.split('=');
+      this._cookies[name] = decodeURIComponent(v);
+    },
+  };
+  const payload = { login: { usuario: { company_id: 5, idDb: 9 }, usu_token: {} } };
+  const http = new FakeHttpClient(JSON.stringify(payload));
+  const cipher = new FakeCipher();
+  const service = new AuthService(http as any, cipher as any);
+
+  let result: any;
+  service.login({ email: 'a', password: 'b' }).subscribe((r: any) => {
+    result = r;
+  });
+
+  assert.strictEqual(result.login.usuario.company_id, 5);
+  assert.strictEqual(getCookie('from_company_id'), '5');
+  assert.strictEqual(getCookie('from_user_id'), '9');
+});

--- a/tests/node_modules/@angular/common/http/index.d.ts
+++ b/tests/node_modules/@angular/common/http/index.d.ts
@@ -1,0 +1,7 @@
+export declare class HttpHeaders {
+  constructor(init?: any);
+}
+export declare class HttpClient {
+  post(url: string, body: any, opts: any): any;
+  delete<T>(url: string, opts: any): any;
+}

--- a/tests/node_modules/@angular/common/http/index.js
+++ b/tests/node_modules/@angular/common/http/index.js
@@ -1,0 +1,8 @@
+class HttpHeaders {
+  constructor(init) {}
+}
+class HttpClient {
+  post(url, body, opts) { return { pipe() { return { subscribe() {} }; } }; }
+  delete(url, opts) { return { subscribe() {} }; }
+}
+module.exports = { HttpClient, HttpHeaders };

--- a/tests/node_modules/rxjs/operators/index.d.ts
+++ b/tests/node_modules/rxjs/operators/index.d.ts
@@ -1,0 +1,1 @@
+export declare function map(fn: (value: any) => any): (source: { subscribe(cb: (v:any)=>void): void }) => { subscribe(cb: (v:any)=>void): void };

--- a/tests/node_modules/rxjs/operators/index.js
+++ b/tests/node_modules/rxjs/operators/index.js
@@ -1,0 +1,3 @@
+exports.map = fn => source => ({
+  subscribe(cb){ source.subscribe(value => cb(fn(value))); }
+});

--- a/tests/stubs/angular-common-http.ts
+++ b/tests/stubs/angular-common-http.ts
@@ -1,0 +1,12 @@
+export class HttpHeaders {
+  constructor(_?: any) {}
+}
+
+export class HttpClient {
+  post(_url: string, _body: any, _opts: any) {
+    return null as any;
+  }
+  delete<T>(_url: string, _opts: any) {
+    return null as any;
+  }
+}

--- a/tests/stubs/crypto-js.ts
+++ b/tests/stubs/crypto-js.ts
@@ -1,0 +1,9 @@
+export const AES = {
+  encrypt(data: string, _key?: string) {
+    return { toString: (_enc?: any) => data };
+  },
+  decrypt(text: string, _key?: string) {
+    return { toString: (_enc?: any) => text };
+  },
+};
+export const enc = { Utf8: 'utf8' };

--- a/tests/stubs/rxjs-operators.ts
+++ b/tests/stubs/rxjs-operators.ts
@@ -1,0 +1,7 @@
+export function map(fn: (value: any) => any) {
+  return (source: { subscribe: (cb: (value: any) => void) => void }) => ({
+    subscribe(cb: (value: any) => void) {
+      source.subscribe((value: any) => cb(fn(value)));
+    },
+  });
+}

--- a/tests/stubs/socket.io-client.ts
+++ b/tests/stubs/socket.io-client.ts
@@ -1,6 +1,7 @@
 export interface Socket {
   on(event: string, cb: (...args: any[]) => void): this;
   emit(event: string, payload?: any): void;
+  disconnect(): void;
 }
 
 export function io(_url?: string, _options?: any): Socket {
@@ -9,6 +10,7 @@ export function io(_url?: string, _options?: any): Socket {
       return this;
     },
     emit() {},
+    disconnect() {},
   } as Socket;
 }
 

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -9,10 +9,20 @@
     "paths": {
       "socket.io-client": ["tests/stubs/socket.io-client"],
       "rxjs": ["tests/stubs/rxjs"],
-      "@angular/core": ["tests/stubs/angular-core"]
+      "@angular/core": ["tests/stubs/angular-core"],
+      "@angular/common/http": ["tests/stubs/angular-common-http"],
+      "rxjs/operators": ["tests/stubs/rxjs-operators"],
+      "crypto-js": ["tests/stubs/crypto-js"]
     }
   },
-  "include": ["tests/**/*.ts", "src/app/core/socket/**/*.ts", "tests/typings/**/*.d.ts"],
+  "include": [
+    "tests/**/*.ts",
+    "src/app/core/socket/**/*.ts",
+    "src/app/core/auth/auth.service.ts",
+    "src/app/core/auth/encrypt.service.ts",
+    "src/app/shared/utils/cookies.ts",
+    "tests/typings/**/*.d.ts"
+  ],
   "typeAcquisition": {
     "enable": false
   }


### PR DESCRIPTION
## Summary
- add `removeCookie` helper and use it on logout
- disconnect socket service when dashboard unloads or on logout
- fix socket handler for `notification:list:ack`
- test AuthService cookie behavior
- add stubs for testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68791bcba1e4832d832e88e41419cb76