### PR TITLE
Update cookies for notification sender

### DIFF
--- a/docs/NOTIFICATION_GUIDE.md
+++ b/docs/NOTIFICATION_GUIDE.md
@@ -16,8 +16,8 @@ Envíe un `POST` a `/api/notifications` con el mismo cuerpo que se envía por el
 
 ```ts
 const payload = {
-  from_user_id: usuario.idDb,
-  from_company_id: usuario.company_id,
+  from_user_id: usuario.usu_id,
+  from_company_id: usuario.emp_id,
   to_user_id: destinatario,
   to_company_id: null,
   tipo: 10,

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -32,11 +32,11 @@ export class AuthService {
             localStorage.setItem('refreshToken', tokens.refreshToken);
           }
           const user = decrypted.login?.usuario;
-          if (user?.company_id) {
-            setCookie('from_company_id', String(user.company_id));
+          if (user?.emp_id) {
+            setCookie('from_company_id', String(user.emp_id));
           }
-          if (user?.idDb) {
-            setCookie('from_user_id', String(user.idDb));
+          if (user?.usu_id) {
+            setCookie('from_user_id', String(user.usu_id));
           }
           return decrypted;
         })

--- a/tests/auth.service.test.ts
+++ b/tests/auth.service.test.ts
@@ -43,7 +43,7 @@ test('login sets user/company cookies', () => {
       this._cookies[name] = decodeURIComponent(v);
     },
   };
-  const payload = { login: { usuario: { company_id: 5, idDb: 9 }, usu_token: {} } };
+  const payload = { login: { usuario: { emp_id: 5, usu_id: 9 }, usu_token: {} } };
   const http = new FakeHttpClient(JSON.stringify(payload));
   const cipher = new FakeCipher();
   const service = new AuthService(http as any, cipher as any);
@@ -53,7 +53,7 @@ test('login sets user/company cookies', () => {
     result = r;
   });
 
-  assert.strictEqual(result.login.usuario.company_id, 5);
+  assert.strictEqual(result.login.usuario.emp_id, 5);
   assert.strictEqual(getCookie('from_company_id'), '5');
   assert.strictEqual(getCookie('from_user_id'), '9');
 });


### PR DESCRIPTION
## Summary
- store `emp_id` and `usu_id` in cookies on login
- update documentation to use those fields when creating a notification
- adjust unit tests for new property names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687927a2317c832da515172a7ede7f2e