### PR TITLE
Set sender cookies when creating notifications

### DIFF
--- a/docs/NOTIFICATION_GUIDE.md
+++ b/docs/NOTIFICATION_GUIDE.md
@@ -24,6 +24,9 @@ const payload = {
   data: { ... }
 };
 
+// El SocketService añade automáticamente `from_company_id` y `from_user_id`
+// leyendo las cookies con esos nombres cuando se envía la notificación.
+
 this.http.post(`${environment.apiUrl}/api/notifications`, payload).subscribe();
 this.socket.emit('crea-notificacion', payload);
 ```

--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import io, { Socket } from 'socket.io-client';
 import { BehaviorSubject } from 'rxjs';
 import { environment } from '../../../environments/environment';
+import { getCookie } from '../../shared/utils/cookies';
 import {
   Notificacion,
   NotificationDelete,
@@ -168,8 +169,13 @@ export class SocketService {
   }
 
   createNotification(payload: Notificacion): void {
-    console.log('SocketService: createNotification', payload);
-    this.socket?.emit('crea-notificacion', payload);
+    const enriched: Notificacion = {
+      ...payload,
+      from_company_id: Number(getCookie('from_company_id')) || 0,
+      from_user_id: Number(getCookie('from_user_id')) || 0,
+    };
+    console.log('SocketService: createNotification', enriched);
+    this.socket?.emit('crea-notificacion', enriched);
   }
 
   requestList(params: NotificationListParams = {}): void {

--- a/tests/socket.service.test.ts
+++ b/tests/socket.service.test.ts
@@ -66,9 +66,11 @@ test('createNotification emits correct payload', () => {
   const socket = new FakeSocket();
   service.setSocketForTesting(socket as any);
 
+  (globalThis as any).document = { cookie: 'from_company_id=9; from_user_id=8' };
+
   const payload = {
-    from_company_id: 1,
-    from_user_id: 2,
+    from_company_id: 0,
+    from_user_id: 0,
     to_company_id: 3,
     to_user_id: 4,
     title: 't',
@@ -80,7 +82,11 @@ test('createNotification emits correct payload', () => {
   service.createNotification(payload as any);
   assert.deepStrictEqual(socket.emitted[0], {
     event: 'crea-notificacion',
-    payload,
+    payload: {
+      ...payload,
+      from_company_id: 9,
+      from_user_id: 8,
+    },
   });
 });
 


### PR DESCRIPTION
## Summary
- auto-populate sender fields from cookies when creating notifications
- document automatic sender cookie usage
- update unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687928f804a4832d8d5ccb47a2ea4651