### PR TITLE
Implement socket connection at app start

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { SocketService } from './core/socket/socket.service';
 
 @Component({
   selector: 'app-root',
@@ -7,4 +8,16 @@ import { RouterOutlet } from '@angular/router';
   imports: [RouterOutlet],
   template: '<router-outlet></router-outlet>'
 })
-export class AppComponent {}
+export class AppComponent implements OnInit, OnDestroy {
+  constructor(private readonly socketService: SocketService) {}
+
+  ngOnInit(): void {
+    this.socketService.connect();
+    this.socketService.requestList();
+    this.socketService.requestUnseenCount();
+  }
+
+  ngOnDestroy(): void {
+    this.socketService.disconnect();
+  }
+}

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -22,7 +22,7 @@ export class AuthService {
       .post(this.loginUrl, encrypted, { headers, responseType: 'text' })
       .pipe(
         map((resp) => {
-          const decrypted = JSON.parse(this.cipher.decrypt(resp))
+          const decrypted = this.cipher.decrypt(resp)
           const tokens = decrypted.login?.usu_token || {}
           if (tokens.sessionToken) {
             localStorage.setItem('sessionToken', tokens.sessionToken)

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   OnInit,
-  OnDestroy,
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -34,7 +33,7 @@ import { AuthFacade } from '../auth/data-access/auth.facade';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DashboardComponent implements OnInit, OnDestroy {
+export class DashboardComponent implements OnInit {
   constructor(
     private socketService: SocketService,
     private router: Router,
@@ -42,7 +41,6 @@ export class DashboardComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.socketService.connect();
     this.socketService.requestList();
     this.socketService.requestUnseenCount();
   }
@@ -70,7 +68,4 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.router.navigate(['/auth/login']);
   }
 
-  ngOnDestroy(): void {
-    this.socketService.disconnect();
-  }
 }

--- a/tests/auth.service.test.ts
+++ b/tests/auth.service.test.ts
@@ -43,7 +43,7 @@ test('login sets user/company cookies', () => {
       this._cookies[name] = decodeURIComponent(v);
     },
   };
-  const payload = { login: { usuario: { emp_id: 5, usu_id: 9 }, usu_token: {} } };
+  const payload = { login: { usu: { emp_id: 5, usu_id: 9 }, usu_token: {} } };
   const http = new FakeHttpClient(JSON.stringify(payload));
   const cipher = new FakeCipher();
   const service = new AuthService(http as any, cipher as any);
@@ -53,7 +53,7 @@ test('login sets user/company cookies', () => {
     result = r;
   });
 
-  assert.strictEqual(result.login.usuario.emp_id, 5);
+  assert.strictEqual(result.login.usu.emp_id, 5);
   assert.strictEqual(getCookie('from_company_id'), '5');
   assert.strictEqual(getCookie('from_user_id'), '9');
 });


### PR DESCRIPTION
## Summary
- connect to SocketService when the app boots so notifications are loaded immediately
- request notifications and unseen count on Dashboard init without reconnecting
- fix AuthService to avoid double JSON.parse
- update auth service test to match new response shape

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687963592908832d88ad6b0489087170