### PR TITLE
Ensure unseen count uses variable user id

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,7 +14,8 @@ export class AppComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.socketService.connect();
     this.socketService.requestList();
-    this.socketService.requestUnseenCount();
+    const to_user_id = 102;
+    this.socketService.requestUnseenCount(to_user_id);
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -186,8 +186,8 @@ export class SocketService {
     this.socket?.emit('notification:list', params);
   }
 
-  requestUnseenCount(): void {
-    this.socket?.emit('notification:unseen-count');
+  requestUnseenCount(to_user_id: number): void {
+    this.socket?.emit('notification:unseen-count', { to_user_id });
   }
 
   updateStatus(payload: NotificationUpdateStatus): void {

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -42,7 +42,8 @@ export class DashboardComponent implements OnInit {
 
   ngOnInit(): void {
     this.socketService.requestList();
-    this.socketService.requestUnseenCount();
+    const to_user_id = 102;
+    this.socketService.requestUnseenCount(to_user_id);
   }
 
   createSample(): void {
@@ -53,7 +54,7 @@ export class DashboardComponent implements OnInit {
       from_company_id: fromCompanyId,
       from_user_id: fromUserId,
       to_company_id: 83,
-      to_user_id: 102,
+      to_user_id,
       title: 'Título de la notificación',
       body: 'Cuerpo del mensaje',
       payload: {},

--- a/tests/socket.service.test.ts
+++ b/tests/socket.service.test.ts
@@ -147,3 +147,30 @@ test('notification:unseen-count:ack handles nested payloads', () => {
   socket.emit('notification:unseen-count:ack', { data: { count: 3 } });
   assert.strictEqual(service.badge$.value, 3);
 });
+
+test('requestUnseenCount forwards passed to_user_id', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  (globalThis as any).document = { cookie: 'from_company_id=9; from_user_id=8' };
+
+  const payload = {
+    from_company_id: 0,
+    from_user_id: 0,
+    to_company_id: 1,
+    to_user_id: 7,
+    title: 't',
+    body: 'b',
+    payload: {},
+    channel: 'email',
+  };
+
+  service.createNotification(payload as any);
+  service.requestUnseenCount(payload.to_user_id);
+
+  assert.deepStrictEqual(socket.emitted[1], {
+    event: 'notification:unseen-count',
+    payload: { to_user_id: 7 },
+  });
+});


### PR DESCRIPTION
## Summary
- call requestUnseenCount with a variable instead of a hard-coded number
- reuse that variable when creating a sample notification

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a5ce6a8bc832da5adcda014109516