### PR TITLE
Fix socket url

### DIFF
--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -29,8 +29,8 @@ export class SocketService {
 
   connect(): void {
     const token = localStorage.getItem('sessionToken') || '';
-    console.log('SocketService: connecting to http://localhost:4000');
-    this.socket = io('http://localhost:4000', {
+    console.log('SocketService: connecting to', environment.socketUrl);
+    this.socket = io(environment.socketUrl, {
       auth: { sessionToken: token },
     });
     this.socket.on('connect', () =>

--- a/tests/stubs/angular-common-http.ts
+++ b/tests/stubs/angular-common-http.ts
@@ -12,7 +12,4 @@ export class HttpClient {
   delete<T>(_url: string, _opts: any) {
     return null as any;
   }
-  get<T>(_url: string, _opts?: any) {
-    return null as any;
-  }
 }


### PR DESCRIPTION
## Summary
- use `environment.socketUrl` instead of a hardcoded URL for `SocketService`
- clean duplicated stub method so tests compile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a868eb608832daacfa1db29804650