### PR TITLE
Improve notification payload parsing

### DIFF
--- a/src/app/core/notifications/notification.service.ts
+++ b/src/app/core/notifications/notification.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { map } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
@@ -10,9 +11,28 @@ export class NotificationService {
   constructor(private http: HttpClient) {}
   
   fetchList(page = 1, limit = 10) {
-    return this.http.get<any[]>(this.listUrl, {
+    return this.http.get<any>(this.listUrl, {
       params: { page, limit },
-    });
+    }).pipe(
+      // The API may return either an array directly or wrap it under
+      // properties like `list`, `data.list` or `results`. Normalize the
+      // response so consumers always receive an array.
+      map((resp: any) =>
+        Array.isArray(resp)
+          ? resp
+          : Array.isArray(resp?.list)
+          ? resp.list
+          : Array.isArray(resp?.data?.list)
+          ? resp.data.list
+          : Array.isArray(resp?.results)
+          ? resp.results
+          : Array.isArray(resp?.data?.results)
+          ? resp.data.results
+          : Array.isArray(resp?.data)
+          ? resp.data
+          : []
+      )
+    );
   }
 
   fetchBadge() {

--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -58,6 +58,10 @@ export class SocketService {
         ? payload.data.list
         : Array.isArray(payload?.list)
         ? payload.list
+        : Array.isArray(payload?.results)
+        ? payload.results
+        : Array.isArray(payload?.data?.results)
+        ? payload.data.results
         : Array.isArray(payload?.data)
         ? payload.data
         : [];
@@ -85,6 +89,14 @@ export class SocketService {
           ? resp.data
           : Array.isArray(resp?.data?.data)
           ? resp.data.data
+          : Array.isArray(resp?.data?.results)
+          ? resp.data.results
+          : Array.isArray(resp?.data?.list)
+          ? resp.data.list
+          : Array.isArray(resp?.results)
+          ? resp.results
+          : Array.isArray(resp?.list)
+          ? resp.list
           : [];
         this.notifications$.next(arr);
       }

--- a/tests/socket.service.test.ts
+++ b/tests/socket.service.test.ts
@@ -31,6 +31,26 @@ test('notification:list:ack handles object payloads', () => {
   assert.deepStrictEqual(service.notifications$.value, list);
 });
 
+test('notification:list:ack supports results property', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  const list = [{ uuid: 'b' }];
+  socket.emit('notification:list:ack', { data: { results: list } });
+  assert.deepStrictEqual(service.notifications$.value, list);
+});
+
+test('notification:list handles results property', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  const list = [{ uuid: 'r1' }];
+  socket.emit('notification:list', { results: list });
+  assert.deepStrictEqual(service.notifications$.value, list);
+});
+
 test('markSeen emits correct payload', () => {
   const service = new SocketService();
   const socket = new FakeSocket();


### PR DESCRIPTION
## Summary
- normalize HTTP notification list results
- add support for `results` in socket payloads
- test new parsing logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a8ae710a4832d84b87ca0c1d81ae9