### PR TITLE
Fix socket connection token handling

### DIFF
--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -31,7 +31,7 @@ export class SocketService {
     const token = localStorage.getItem('sessionToken') || '';
     console.log('SocketService: connecting to', environment.socketUrl);
     this.socket = io(environment.socketUrl, {
-      auth: { sessionToken: token },
+      query: { token },
     });
     this.socket.on('connect', () =>
       console.log('SocketService: connected to socket')


### PR DESCRIPTION
## Summary
- connect to socket.io server using query string token instead of auth option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a8fac0790832db037ebb0b239b2ff