### PR TITLE
Add sender-based filters for notification list

### DIFF
--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -23,7 +23,7 @@ export class AuthService {
       .post(this.loginUrl, encrypted, { headers, responseType: 'text' })
       .pipe(
         map((resp) => {
-          const decrypted = JSON.parse(this.cipher.decrypt(resp))
+          const decrypted = this.cipher.decrypt(resp)
           const tokens = decrypted.login?.usu_token || {};
           if (tokens.sessionToken) {
             localStorage.setItem('sessionToken', tokens.sessionToken)

--- a/src/app/core/notifications/notification.service.ts
+++ b/src/app/core/notifications/notification.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { getCookie } from '../../shared/utils/cookies';
+import { NotificationListParams } from '../socket/notification.types';
 import { map } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 
@@ -10,9 +12,15 @@ export class NotificationService {
 
   constructor(private http: HttpClient) {}
   
-  fetchList(page = 1, limit = 10) {
+  fetchList(params: NotificationListParams = {}) {
+    const defaults: NotificationListParams = {
+      page: 1,
+      limit: 10,
+      from_company_id: Number(getCookie('from_company_id')),
+      from_user_id: Number(getCookie('from_user_id')),
+    };
     return this.http.get<any>(this.listUrl, {
-      params: { page, limit },
+      params: { ...defaults, ...params },
     }).pipe(
       // The API may return either an array directly or wrap it under
       // properties like `list`, `data.list` or `results`. Normalize the

--- a/src/app/core/socket/notification.types.ts
+++ b/src/app/core/socket/notification.types.ts
@@ -31,6 +31,8 @@ export interface NotificationGet {
 export interface NotificationListParams {
   page?: number;
   limit?: number;
+  from_company_id?: number;
+  from_user_id?: number;
 }
 
 export interface NotificationHistory {

--- a/src/app/core/socket/socket.service.ts
+++ b/src/app/core/socket/socket.service.ts
@@ -234,7 +234,11 @@ export class SocketService {
   }
 
   requestList(params: NotificationListParams = {}): void {
-    this.socket?.emit('notification:list', params);
+    const defaults: NotificationListParams = {
+      from_company_id: Number(getCookie('from_company_id')),
+      from_user_id: Number(getCookie('from_user_id')),
+    };
+    this.socket?.emit('notification:list', { ...defaults, ...params });
   }
 
   requestUnseenCount(to_user_id: number): void {
@@ -257,9 +261,11 @@ export class SocketService {
     if (!this.notificationService) {
       return;
     }
-    this.notificationService.fetchList(1, 10).subscribe((list) => {
-      this.notifications$.next(list as any[]);
-    });
+    this.notificationService
+      .fetchList()
+      .subscribe((list) => {
+        this.notifications$.next(list as any[]);
+      });
     this.notificationService
       .fetchBadge()
       .subscribe((count) => this.badge$.next(Number(count)));

--- a/tests/socket.service.test.ts
+++ b/tests/socket.service.test.ts
@@ -116,6 +116,7 @@ test('createNotification emits correct payload', () => {
     getItem: (k: string) =>
       k === 'payload' ? JSON.stringify({ user_id: 9, company_id: 8 }) : null,
   } as any;
+  (globalThis as any).document = { cookie: 'from_user_id=9; from_company_id=8' } as any;
 
   const payload = {
     to_company_id: 3,
@@ -200,6 +201,7 @@ test('requestUnseenCount forwards passed to_user_id', () => {
     getItem: (k: string) =>
       k === 'payload' ? JSON.stringify({ user_id: 1, company_id: 2 }) : null,
   } as any;
+  (globalThis as any).document = { cookie: 'from_user_id=1; from_company_id=2' } as any;
 
   const payload = {
     to_company_id: 1,
@@ -221,6 +223,21 @@ test('requestUnseenCount forwards passed to_user_id', () => {
   assert.deepStrictEqual(socket.emitted[1], {
     event: 'notification:unseen-count',
     payload: { to_user_id: 7 },
+  });
+});
+
+test('requestList emits default sender ids', () => {
+  const service = new SocketService();
+  const socket = new FakeSocket();
+  service.setSocketForTesting(socket as any);
+
+  (globalThis as any).document = { cookie: 'from_user_id=5; from_company_id=6' } as any;
+
+  service.requestList({ page: 2, limit: 5 });
+
+  assert.deepStrictEqual(socket.emitted[0], {
+    event: 'notification:list',
+    payload: { page: 2, limit: 5, from_user_id: 5, from_company_id: 6 },
   });
 });
 


### PR DESCRIPTION
## Summary
- extend `NotificationListParams` with `from_company_id` and `from_user_id`
- include these fields when requesting the notification list via sockets and HTTP
- read sender ids from cookies in services
- adjust tests and fix auth service JSON handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aaa8ec638832da5682e3b5d504fe6